### PR TITLE
[settings] api 요청시 경로 rewriter 설정

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,6 +8,14 @@ const nextConfig = {
       @import "@/shared/styles/base/functions";
     `,
   },
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${process.env.API_HOST}/api/:path*`,
+      },
+    ]
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

nextjs에서 ```GET:  /api/ 어쩌구```로 요청을 보낼 시에 api 요청과 페이지 요청이 충돌하여 문제가 생깁니다.
이를 해결하고자 next.config 파일을 수정하고, .env 파일를 통해 host룰 돌려줄  수 있도록 설정했습니다.
개발 환경에서는 .env.development.local에 다음을 추가합니다.
```
API_HOST=http://localhost:8080
```
실 api 주소가 나오면 실주소로 .env 파일을 업데이트하면 될 것 같습니다.

## 🔧 변경 사항
```/api
```js
// next.config.mjs
+  async rewrites() {
    return [
      {
        // source로 들어오는 요청을 destination주소로 돌려줌
        source: '/api/:path*',
        destination: `${process.env.API_HOST}/api/:path*`,
      },
    ]
  },
```

## 🙏 리뷰 참고 (선택 사항)

[참고문서 next.js rewirte](https://nextjs.org/docs/pages/api-reference/next-config-js/rewrites)
