### PR TITLE
[Feat] 회원가입 유형 선택 페이지

### DIFF
--- a/app/(landing)/signup/_stores/use-signup-store.ts
+++ b/app/(landing)/signup/_stores/use-signup-store.ts
@@ -1,13 +1,13 @@
 import { create } from 'zustand'
 
-import { RoleSelectType } from '@/shared/types/user'
+import { UserType } from '@/shared/types/user'
 
 interface StateModel {
-  userType: RoleSelectType | null
+  userType: UserType | null
 }
 
 interface ActionModel {
-  setUserType: (userType: RoleSelectType) => void
+  setUserType: (userType: UserType) => void
 }
 
 interface ActionsModel {

--- a/app/(landing)/signup/_stores/use-signup-store.ts
+++ b/app/(landing)/signup/_stores/use-signup-store.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand'
+
+import { RoleSelectType } from '@/shared/types/user'
+
+interface StateModel {
+  userType: RoleSelectType | null
+}
+
+interface ActionModel {
+  setUserType: (userType: RoleSelectType) => void
+}
+
+interface ActionsModel {
+  actions: ActionModel
+}
+
+const initialState = {
+  userType: null,
+} as const
+
+const useSignupStore = create<StateModel & ActionsModel>((set) => ({
+  ...initialState,
+  actions: {
+    setUserType: (userType) => set((state) => ({ ...state, userType })),
+  },
+}))
+
+export default useSignupStore

--- a/app/(landing)/signup/_ui/step/styles.module.scss
+++ b/app/(landing)/signup/_ui/step/styles.module.scss
@@ -1,7 +1,7 @@
 .step {
   display: flex;
   justify-content: center;
-  margin: 20px 0;
+  margin: 135px 0 0;
 }
 
 .bar {

--- a/app/(landing)/signup/_ui/user-type-card/index.tsx
+++ b/app/(landing)/signup/_ui/user-type-card/index.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation'
 
+import useSignupStore from '@/app/(landing)/signup/_stores/use-signup-store'
 import classNames from 'classnames/bind'
 
 import { PATH } from '@/shared/constants/path'
@@ -19,9 +20,10 @@ interface Props {
 
 const UserTypeCard = ({ userType, title, highlight }: Props) => {
   const router = useRouter()
+  const { setUserType } = useSignupStore((state) => state.actions)
 
   const handleTypeSelect = () => {
-    // TODO: role 저장
+    setUserType(userType)
     router.push(PATH.SIGN_UP_TERMS_OF_USE)
   }
 

--- a/app/(landing)/signup/_ui/user-type-card/index.tsx
+++ b/app/(landing)/signup/_ui/user-type-card/index.tsx
@@ -12,12 +12,12 @@ import styles from './styles.module.scss'
 const cx = classNames.bind(styles)
 
 interface Props {
-  role: RoleSelectType
+  userType: RoleSelectType
   title: string
   highlight: string
 }
 
-const UserTypeCard = ({ role, title, highlight }: Props) => {
+const UserTypeCard = ({ userType, title, highlight }: Props) => {
   const router = useRouter()
 
   const handleTypeSelect = () => {

--- a/app/(landing)/signup/_ui/user-type-card/index.tsx
+++ b/app/(landing)/signup/_ui/user-type-card/index.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+import classNames from 'classnames/bind'
+
+import { PATH } from '@/shared/constants/path'
+import { RoleSelectType } from '@/shared/types/user'
+
+import styles from './styles.module.scss'
+
+const cx = classNames.bind(styles)
+
+interface Props {
+  role: RoleSelectType
+  title: string
+  highlight: string
+}
+
+const UserTypeCard = ({ role, title, highlight }: Props) => {
+  const router = useRouter()
+
+  const handleTypeSelect = () => {
+    // TODO: role 저장
+    router.push(PATH.SIGN_UP_TERMS_OF_USE)
+  }
+
+  return (
+    <button className={cx('card')} onClick={handleTypeSelect}>
+      <h2 className={cx('title')}>{title}</h2>
+      <hr className={cx('line')} />
+      <p className={cx('contents')}>
+        인베스트메틱을 통해 <br />
+        <span className={cx('highlight')}>{highlight}</span>해보세요!
+      </p>
+    </button>
+  )
+}
+
+export default UserTypeCard

--- a/app/(landing)/signup/_ui/user-type-card/index.tsx
+++ b/app/(landing)/signup/_ui/user-type-card/index.tsx
@@ -6,14 +6,14 @@ import useSignupStore from '@/app/(landing)/signup/_stores/use-signup-store'
 import classNames from 'classnames/bind'
 
 import { PATH } from '@/shared/constants/path'
-import { RoleSelectType } from '@/shared/types/user'
+import { UserType } from '@/shared/types/user'
 
 import styles from './styles.module.scss'
 
 const cx = classNames.bind(styles)
 
 interface Props {
-  userType: RoleSelectType
+  userType: UserType
   title: string
   highlight: string
 }

--- a/app/(landing)/signup/_ui/user-type-card/styles.module.scss
+++ b/app/(landing)/signup/_ui/user-type-card/styles.module.scss
@@ -3,6 +3,12 @@
   padding: 43px 44px 53px;
   text-align: left;
   background-color: $color-white;
+  border: 2px solid $color-white;
+  transition: 0.2s ease-in-out;
+
+  &:hover {
+    border: 2px solid $color-orange-400;
+  }
 }
 
 .title {

--- a/app/(landing)/signup/_ui/user-type-card/styles.module.scss
+++ b/app/(landing)/signup/_ui/user-type-card/styles.module.scss
@@ -1,0 +1,26 @@
+.card {
+  width: 100%;
+  padding: 43px 44px 53px;
+  text-align: left;
+  background-color: $color-white;
+}
+
+.title {
+  @include typo-h2;
+}
+
+.line {
+  width: 100%;
+  margin: 30px 0;
+  border: 1px solid $color-gray-200;
+}
+
+.contents {
+  @include typo-h4;
+  color: $color-gray-500;
+  line-height: 140%;
+}
+
+.highlight {
+  color: $color-orange-600;
+}

--- a/app/(landing)/signup/user-type/page.module.scss
+++ b/app/(landing)/signup/user-type/page.module.scss
@@ -1,0 +1,7 @@
+.card-container {
+  display: flex;
+  gap: 32px;
+  width: 100%;
+  max-width: 952px;
+  margin: 120px auto 0;
+}

--- a/app/(landing)/signup/user-type/page.tsx
+++ b/app/(landing)/signup/user-type/page.tsx
@@ -1,13 +1,20 @@
 import Step from '@/app/(landing)/signup/_ui/step'
+import UserTypeCard from '@/app/(landing)/signup/_ui/user-type-card'
+import classNames from 'classnames/bind'
 
-import { PATH } from '@/shared/constants/path'
-import { LinkButton } from '@/shared/ui/link-button'
+import styles from './page.module.scss'
+
+const cx = classNames.bind(styles)
 
 const UserTypePage = () => {
   return (
     <>
       <Step />
-      <LinkButton href={PATH.SIGN_UP_TERMS_OF_USE}>다음</LinkButton>
+      <section className={cx('card-container')}>
+        <h2 className="visually-hidden">회원 유형 선택</h2>
+        <UserTypeCard userType="investor" title="투자자" highlight="다양한 투자 전략을 구독" />
+        <UserTypeCard userType="trader" title="트레이더" highlight="나만의 투자 전략을 공유" />
+      </section>
     </>
   )
 }

--- a/shared/styles/global.scss
+++ b/shared/styles/global.scss
@@ -17,3 +17,15 @@ textarea {
     opacity: 1; /* Firefox */
   }
 }
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  overflow: hidden;
+  white-space: nowrap;
+}

--- a/shared/types/user.ts
+++ b/shared/types/user.ts
@@ -7,3 +7,5 @@ export interface UserModel {
 }
 
 export type RoleType = 'trader' | 'investor' | 'trader_admin' | 'investor_admin'
+
+export type RoleSelectType = 'trader' | 'investor'

--- a/shared/types/user.ts
+++ b/shared/types/user.ts
@@ -6,6 +6,6 @@ export interface UserModel {
   role: RoleType
 }
 
-export type RoleType = 'trader' | 'investor' | 'trader_admin' | 'investor_admin'
+export type UserType = 'trader' | 'investor'
 
-export type RoleSelectType = 'trader' | 'investor'
+export type RoleType = UserType | `${UserType}_admin`


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

회원가입 유형 선택 페이지 작업했습니다!
- 회원가입 유형 선택 페이지 퍼블리싱
- 선택한 유형을 저장할 store 추가

기존 디자인에는 다음 버튼이 있었는데, 유형을 선택했을때 바로 다음으로 넘어가는게 나을 것 같아서 디자이너님과 상의 후 버튼을 빼기로 결정했습니다!

## 🔧 변경 사항

- 웹 접근성 향상을 위해 사용되는 `.visually-hidden` 클래스를 global 스타일에 추가해뒀습니다

## 📸 스크린샷 (권장)

![image](https://github.com/user-attachments/assets/dfcf36d7-0a88-4442-bc27-b0000227bc78)

## 🙏 리뷰 참고 (선택 사항)

- 회원 유형, 약관 동의 여부를 저장해둘 필요가 있다는 생각이 들어서 store을 추가했는데 혹시 다른 좋은 방법이 있다면 코멘트 남겨주세요!

## 📄 기타 (선택 사항)

- /signup/user-type 경로에서 확인!
