### PR TITLE
[Feat] 전략상세 사이드정보 아이템 컴포넌트, 스토리북 추가

### DIFF
--- a/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/details-side-item.stories.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/details-side-item.stories.tsx
@@ -1,0 +1,47 @@
+import DetailsSideItem, {
+  TitleType,
+} from '@/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item'
+import type { Meta, StoryFn } from '@storybook/react'
+
+const meta: Meta<typeof DetailsSideItem> = {
+  title: 'components/DetailsSideItem',
+  component: DetailsSideItem,
+  tags: ['autodocs'],
+}
+
+const sideItem: StoryFn<{ data: { title: TitleType; data: string | number }[] }> = ({ data }) => (
+  <div style={{ width: '100%', height: '100%', background: '#fafafa', padding: '20px' }}>
+    {data.map((item, idx) => (
+      <DetailsSideItem
+        key={item.title}
+        title={item.title}
+        data={item.data}
+        hasGap={idx === 3 || idx === 5 ? false : true}
+      />
+    ))}
+  </div>
+)
+export const Default = sideItem.bind({})
+Default.args = {
+  data: [{ title: '투자 원금', data: '10,000,000' }],
+}
+
+export const Trader = sideItem.bind({})
+Trader.args = {
+  data: [{ title: '트레이더', data: '수밍' }],
+}
+
+export const LayoutExample = sideItem.bind({})
+LayoutExample.args = {
+  data: [
+    { title: '트레이더', data: '수밍' },
+    { title: '최소 투자 금액', data: '1억 ~ 2억' },
+    { title: '투자 원금', data: '10,000,000' },
+    { title: 'KP Ratio', data: 0.3993 },
+    { title: 'SM SCORE', data: 67.38 },
+    { title: '최종손익입력일자', data: '2016.04.30' },
+    { title: '등록일', data: '2016.02.30' },
+  ],
+}
+
+export default meta

--- a/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/index.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/index.tsx
@@ -1,0 +1,50 @@
+import classNames from 'classnames/bind'
+
+import { PATH } from '@/shared/constants/path'
+import Avatar from '@/shared/ui/avatar'
+import { LinkButton } from '@/shared/ui/link-button'
+
+import styles from './styles.module.scss'
+
+const cx = classNames.bind(styles)
+
+export type TitleType =
+  | '트레이더'
+  | '최소 투자 금액'
+  | '투자 원금'
+  | 'KP Ratio'
+  | 'SM SCORE'
+  | '최종손익입력일자'
+  | '등록일'
+
+interface Props {
+  title: TitleType
+  data: string | number
+  imageUrl?: string
+  hasGap?: boolean
+}
+
+const DetailsSideItem = ({ title, data, imageUrl, hasGap = true }: Props) => {
+  return (
+    <div className={cx('side-item', hasGap && 'gap')}>
+      <div className={cx('title')}>{title}</div>
+      <div className={cx('data')}>
+        {title === '트레이더' ? (
+          <>
+            <div className={cx('avatar')}>
+              <Avatar size="medium" src={imageUrl} />
+              <p>{data}</p>
+            </div>
+            <LinkButton href={PATH.MY_QUESTIONS} size="small" style={{ height: '30px' }}>
+              문의하기
+            </LinkButton>
+          </>
+        ) : (
+          <p>{data}</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default DetailsSideItem

--- a/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/styles.module.scss
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/styles.module.scss
@@ -1,0 +1,40 @@
+.side-item {
+  width: 276px;
+  height: 100px;
+  background-color: $color-white;
+  padding: 20px 20px 0;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+
+  &.gap {
+    height: 120px;
+    margin-bottom: 20px;
+    border-radius: 5px;
+    padding: 20px;
+  }
+
+  .title {
+    font-weight: $text-bold;
+    font-size: $text-b2;
+    color: $color-gray-500;
+    border-bottom: 0.75px solid $color-gray-500;
+    padding-bottom: 12px;
+  }
+
+  .data {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-top: 12px;
+    .avatar {
+      display: flex;
+      align-items: center;
+      p {
+        margin-left: 5px;
+      }
+    }
+    p {
+      @include typo-b1;
+    }
+  }
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

전략상세 사이드정보 아이템 컴포넌트, 스토리북 추가

## 🔧 변경 사항

- 전략상세 사이드정보 아이템 컴포넌트
- 스토리북 추가

## 📸 스크린샷 (권장)

> 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 🙏 리뷰 참고 (선택 사항)

> 개발 과정에서 다른 분들의 의견이 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요.

## 📄 기타 (선택 사항)

- LinkButton href => 문의글 작성 페이지 path 나오면 href 수정 (현재는 my/questions로 해둠)
