### PR TITLE
[Feat] 전략상세 사이드정보 아이템 컴포넌트, 스토리북 추가

### DIFF
--- a/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/details-side-item.stories.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/details-side-item.stories.tsx
@@ -1,7 +1,6 @@
-import DetailsSideItem, {
-  InformationModel,
-} from '@/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item'
 import type { Meta, StoryFn } from '@storybook/react'
+
+import DetailsSideItem, { InformationModel } from './index'
 
 const meta: Meta<typeof DetailsSideItem> = {
   title: 'components/DetailsSideItem',
@@ -10,16 +9,7 @@ const meta: Meta<typeof DetailsSideItem> = {
   argTypes: {
     information: {
       title: {
-        control: 'select',
-        options: [
-          '트레이더',
-          '최소 투자 금액',
-          '투자 원금',
-          'KP Ratio',
-          'SM SCORE',
-          '최종손익입력일자',
-          '등록일',
-        ],
+        control: 'object',
       },
       data: {
         control: 'text',

--- a/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/details-side-item.stories.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/details-side-item.stories.tsx
@@ -1,0 +1,47 @@
+import DetailsSideItem, {
+  TitleType,
+} from '@/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item'
+import type { Meta, StoryFn } from '@storybook/react'
+
+const meta: Meta<typeof DetailsSideItem> = {
+  title: 'components/DetailsSideItem',
+  component: DetailsSideItem,
+  tags: ['autodocs'],
+}
+
+const sideItem: StoryFn<{ data: { title: TitleType; data: string | number }[] }> = ({ data }) => (
+  <div style={{ width: '100%', height: '100%', background: '#fafafa', padding: '20px' }}>
+    {data.map((item, idx) => (
+      <DetailsSideItem
+        key={item.title}
+        title={item.title}
+        data={item.data}
+        hasGap={idx === 3 || idx === 5 ? false : true}
+      />
+    ))}
+  </div>
+)
+export const Default = sideItem.bind({})
+Default.args = {
+  data: [{ title: '투자 원금', data: '10,000,000' }],
+}
+
+export const Trader = sideItem.bind({})
+Trader.args = {
+  data: [{ title: '트레이더', data: '수밍' }],
+}
+
+export const LayoutExample = sideItem.bind({})
+LayoutExample.args = {
+  data: [
+    { title: '트레이더', data: '수밍' },
+    { title: '최소 투자 금액', data: '1억 ~ 2억' },
+    { title: '투자 원금', data: '10,000,000' },
+    { title: 'KP Ratio', data: 0.3993 },
+    { title: 'SM SCORE', data: 67.38 },
+    { title: '최종손익입력일자', data: '2016.04.30' },
+    { title: '등록일', data: '2016.02.30' },
+  ],
+}
+
+export default meta

--- a/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/details-side-item.stories.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/details-side-item.stories.tsx
@@ -1,5 +1,5 @@
 import DetailsSideItem, {
-  TitleType,
+  InformationModel,
 } from '@/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item'
 import type { Meta, StoryFn } from '@storybook/react'
 
@@ -7,40 +7,48 @@ const meta: Meta<typeof DetailsSideItem> = {
   title: 'components/DetailsSideItem',
   component: DetailsSideItem,
   tags: ['autodocs'],
+  argTypes: {
+    information: {
+      title: {
+        control: 'select',
+        options: [
+          '트레이더',
+          '최소 투자 금액',
+          '투자 원금',
+          'KP Ratio',
+          'SM SCORE',
+          '최종손익입력일자',
+          '등록일',
+        ],
+      },
+      data: {
+        control: 'text',
+      },
+    },
+  },
 }
 
-const sideItem: StoryFn<{ data: { title: TitleType; data: string | number }[] }> = ({ data }) => (
+const sideItems: StoryFn<{ information: InformationModel | InformationModel[] }> = (args) => (
   <div style={{ width: '100%', height: '100%', background: '#fafafa', padding: '20px' }}>
-    {data.map((item, idx) => (
-      <DetailsSideItem
-        key={item.title}
-        title={item.title}
-        data={item.data}
-        hasGap={idx === 3 || idx === 5 ? false : true}
-      />
-    ))}
+    <DetailsSideItem {...args} />
   </div>
 )
-export const Default = sideItem.bind({})
+
+export const Default = sideItems.bind({})
 Default.args = {
-  data: [{ title: '투자 원금', data: '10,000,000' }],
+  information: { title: '투자 원금', data: '10,000,000' },
 }
 
-export const Trader = sideItem.bind({})
+export const Trader = sideItems.bind({})
 Trader.args = {
-  data: [{ title: '트레이더', data: '수밍' }],
+  information: { title: '트레이더', data: '수밍' },
 }
 
-export const LayoutExample = sideItem.bind({})
-LayoutExample.args = {
-  data: [
-    { title: '트레이더', data: '수밍' },
-    { title: '최소 투자 금액', data: '1억 ~ 2억' },
-    { title: '투자 원금', data: '10,000,000' },
+export const Multiple = sideItems.bind({})
+Multiple.args = {
+  information: [
     { title: 'KP Ratio', data: 0.3993 },
     { title: 'SM SCORE', data: 67.38 },
-    { title: '최종손익입력일자', data: '2016.04.30' },
-    { title: '등록일', data: '2016.02.30' },
   ],
 }
 

--- a/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/details-side-item.stories.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/details-side-item.stories.tsx
@@ -6,16 +6,6 @@ const meta: Meta<typeof DetailsSideItem> = {
   title: 'components/DetailsSideItem',
   component: DetailsSideItem,
   tags: ['autodocs'],
-  argTypes: {
-    information: {
-      title: {
-        control: 'object',
-      },
-      data: {
-        control: 'text',
-      },
-    },
-  },
 }
 
 const sideItems: StoryFn<{ information: InformationModel | InformationModel[] }> = (args) => (

--- a/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/index.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/index.tsx
@@ -20,11 +20,11 @@ export type TitleType =
 interface Props {
   title: TitleType
   data: string | number
-  imageUrl?: string
+  profileImage?: string
   hasGap?: boolean
 }
 
-const DetailsSideItem = ({ title, data, imageUrl, hasGap = true }: Props) => {
+const DetailsSideItem = ({ title, data, profileImage, hasGap = true }: Props) => {
   return (
     <div className={cx('side-item', hasGap && 'gap')}>
       <div className={cx('title')}>{title}</div>
@@ -32,7 +32,7 @@ const DetailsSideItem = ({ title, data, imageUrl, hasGap = true }: Props) => {
         {title === '트레이더' ? (
           <>
             <div className={cx('avatar')}>
-              <Avatar src={imageUrl} />
+              <Avatar src={profileImage} />
               <p>{data}</p>
             </div>
             <LinkButton href={PATH.MY_QUESTIONS} size="small" style={{ height: '30px' }}>

--- a/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/index.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/index.tsx
@@ -1,8 +1,5 @@
+import SideItem from '@/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/side-item'
 import classNames from 'classnames/bind'
-
-import { PATH } from '@/shared/constants/path'
-import Avatar from '@/shared/ui/avatar'
-import { LinkButton } from '@/shared/ui/link-button'
 
 import styles from './styles.module.scss'
 
@@ -17,33 +14,35 @@ export type TitleType =
   | '최종손익입력일자'
   | '등록일'
 
-interface Props {
+export interface InformationModel {
   title: TitleType
   data: string | number
-  profileImage?: string
-  hasGap?: boolean
 }
 
-const DetailsSideItem = ({ title, data, profileImage, hasGap = true }: Props) => {
+interface Props {
+  information: InformationModel | InformationModel[]
+  profileImage?: string
+}
+
+const DetailsSideItem = ({ information, profileImage }: Props) => {
+  const isArray = Array.isArray(information)
   return (
-    <div className={cx('side-item', hasGap && 'gap')}>
-      <div className={cx('title')}>{title}</div>
-      <div className={cx('data')}>
-        {title === '트레이더' ? (
-          <>
-            <div className={cx('avatar')}>
-              <Avatar src={profileImage} />
-              <p>{data}</p>
+    <>
+      {isArray ? (
+        <div className={cx('side-items')}>
+          {information.map((item) => (
+            <div key={item.title}>
+              <div className={cx('title')}>{item.title}</div>
+              <div className={cx('data')}>
+                <p>{item.data}</p>
+              </div>
             </div>
-            <LinkButton href={PATH.MY_QUESTIONS} size="small" style={{ height: '30px' }}>
-              문의하기
-            </LinkButton>
-          </>
-        ) : (
-          <p>{data}</p>
-        )}
-      </div>
-    </div>
+          ))}
+        </div>
+      ) : (
+        <SideItem title={information.title} data={information.data} profileImage={profileImage} />
+      )}
+    </>
   )
 }
 

--- a/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/index.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/index.tsx
@@ -1,6 +1,6 @@
-import SideItem from '@/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/side-item'
 import classNames from 'classnames/bind'
 
+import SideItem from './side-item'
 import styles from './styles.module.scss'
 
 const cx = classNames.bind(styles)

--- a/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/index.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/index.tsx
@@ -32,7 +32,7 @@ const DetailsSideItem = ({ title, data, imageUrl, hasGap = true }: Props) => {
         {title === '트레이더' ? (
           <>
             <div className={cx('avatar')}>
-              <Avatar size="medium" src={imageUrl} />
+              <Avatar src={imageUrl} />
               <p>{data}</p>
             </div>
             <LinkButton href={PATH.MY_QUESTIONS} size="small" style={{ height: '30px' }}>

--- a/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/index.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/index.tsx
@@ -1,0 +1,50 @@
+import classNames from 'classnames/bind'
+
+import { PATH } from '@/shared/constants/path'
+import Avatar from '@/shared/ui/avatar'
+import { LinkButton } from '@/shared/ui/link-button'
+
+import styles from './styles.module.scss'
+
+const cx = classNames.bind(styles)
+
+export type TitleType =
+  | '트레이더'
+  | '최소 투자 금액'
+  | '투자 원금'
+  | 'KP Ratio'
+  | 'SM SCORE'
+  | '최종손익입력일자'
+  | '등록일'
+
+interface Props {
+  title: TitleType
+  data: string | number
+  imageUrl?: string
+  hasGap?: boolean
+}
+
+const DetailsSideItem = ({ title, data, imageUrl, hasGap = true }: Props) => {
+  return (
+    <div className={cx('side-item', hasGap && 'gap')}>
+      <div className={cx('title')}>{title}</div>
+      <div className={cx('data')}>
+        {title === '트레이더' ? (
+          <>
+            <div className={cx('avatar')}>
+              <Avatar size="medium" src={imageUrl} />
+              <p>{data}</p>
+            </div>
+            <LinkButton href={PATH.MY_QUESTIONS} size="small" style={{ height: '30px' }}>
+              문의하기
+            </LinkButton>
+          </>
+        ) : (
+          <p>{data}</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default DetailsSideItem

--- a/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/side-item.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/side-item.tsx
@@ -1,0 +1,41 @@
+import { TitleType } from '@/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item'
+import classNames from 'classnames/bind'
+
+import { PATH } from '@/shared/constants/path'
+import Avatar from '@/shared/ui/avatar'
+import { LinkButton } from '@/shared/ui/link-button'
+
+import styles from './styles.module.scss'
+
+const cx = classNames.bind(styles)
+
+interface Props {
+  title: Omit<TitleType, '트레이더' | '최소 투자 금액' | '투자 원금'>
+  data: number | string
+  profileImage?: string
+}
+
+const SideItem = ({ title, data, profileImage }: Props) => {
+  return (
+    <div className={cx('side-item')}>
+      <div className={cx('title')}>{title}</div>
+      <div className={cx('data')}>
+        {title === '트레이더' ? (
+          <>
+            <div className={cx('avatar')}>
+              <Avatar src={profileImage} />
+              <p>{data}</p>
+            </div>
+            <LinkButton href={PATH.MY_QUESTIONS} size="small" style={{ height: '30px' }}>
+              문의하기
+            </LinkButton>
+          </>
+        ) : (
+          <p>{data}</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default SideItem

--- a/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/styles.module.scss
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/styles.module.scss
@@ -30,7 +30,7 @@
       display: flex;
       align-items: center;
       p {
-        margin-left: 5px;
+        margin-left: 11px;
       }
     }
     p {

--- a/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/styles.module.scss
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/styles.module.scss
@@ -1,18 +1,24 @@
 .side-item {
-  width: 276px;
-  height: 100px;
-  background-color: $color-white;
+  height: 120px;
+  padding: 20px;
+}
+
+.side-items {
+  height: 210px;
   padding: 20px 20px 0;
-  border-top-left-radius: 5px;
-  border-top-right-radius: 5px;
-
-  &.gap {
-    height: 120px;
-    margin-bottom: 20px;
-    border-radius: 5px;
-    padding: 20px;
+  .data {
+    p {
+      margin-bottom: 20px;
+    }
   }
+}
 
+.side-item,
+.side-items {
+  width: 276px;
+  background-color: $color-white;
+  border-radius: 5px;
+  margin-bottom: 20px;
   .title {
     font-weight: $text-bold;
     font-size: $text-b2;
@@ -20,21 +26,21 @@
     border-bottom: 0.75px solid $color-gray-500;
     padding-bottom: 12px;
   }
-
   .data {
     display: flex;
     justify-content: space-between;
     align-items: center;
     padding-top: 12px;
-    .avatar {
-      display: flex;
-      align-items: center;
-      p {
-        margin-left: 11px;
-      }
-    }
     p {
       @include typo-b1;
     }
+  }
+}
+
+.avatar {
+  display: flex;
+  align-items: center;
+  p {
+    margin-left: 11px;
   }
 }

--- a/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/styles.module.scss
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item/styles.module.scss
@@ -1,0 +1,40 @@
+.side-item {
+  width: 276px;
+  height: 100px;
+  background-color: $color-white;
+  padding: 20px 20px 0;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+
+  &.gap {
+    height: 120px;
+    margin-bottom: 20px;
+    border-radius: 5px;
+    padding: 20px;
+  }
+
+  .title {
+    font-weight: $text-bold;
+    font-size: $text-b2;
+    color: $color-gray-500;
+    border-bottom: 0.75px solid $color-gray-500;
+    padding-bottom: 12px;
+  }
+
+  .data {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-top: 12px;
+    .avatar {
+      display: flex;
+      align-items: center;
+      p {
+        margin-left: 5px;
+      }
+    }
+    p {
+      @include typo-b1;
+    }
+  }
+}

--- a/app/(dashboard)/strategies/[strategyId]/page.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/page.tsx
@@ -1,27 +1,4 @@
-import DetailsSideItem, {
-  TitleType,
-} from '@/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item'
-
 const StrategyDetailPage = () => {
-  const arr1: { title: TitleType; data: string | number }[] = [
-    { title: '최종손익입력일자', data: '2016.04.30' },
-    { title: '등록일', data: '2016.02.30' },
-  ]
-  const arr2: { title: TitleType; data: string | number }[] = [
-    { title: '최종손익입력일자', data: '2016.04.30' },
-    { title: '등록일', data: '2016.02.30' },
-  ]
-  const trader: { title: TitleType; data: string | number } = { title: '트레이더', data: '수밍' }
-  const arr = [trader, arr1, arr2]
-  return (
-    <>
-      {arr.map((i, idx) => (
-        <div key={idx}>
-          <DetailsSideItem information={i} />
-        </div>
-      ))}
-    </>
-  )
+  return <></>
 }
-
 export default StrategyDetailPage

--- a/app/(dashboard)/strategies/[strategyId]/page.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/page.tsx
@@ -1,5 +1,27 @@
+import DetailsSideItem, {
+  TitleType,
+} from '@/app/(dashboard)/strategies/[strategyId]/_ui/details-side-item'
+
 const StrategyDetailPage = () => {
-  return <></>
+  const arr1: { title: TitleType; data: string | number }[] = [
+    { title: '최종손익입력일자', data: '2016.04.30' },
+    { title: '등록일', data: '2016.02.30' },
+  ]
+  const arr2: { title: TitleType; data: string | number }[] = [
+    { title: '최종손익입력일자', data: '2016.04.30' },
+    { title: '등록일', data: '2016.02.30' },
+  ]
+  const trader: { title: TitleType; data: string | number } = { title: '트레이더', data: '수밍' }
+  const arr = [trader, arr1, arr2]
+  return (
+    <>
+      {arr.map((i, idx) => (
+        <div key={idx}>
+          <DetailsSideItem information={i} />
+        </div>
+      ))}
+    </>
+  )
 }
 
 export default StrategyDetailPage


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

전략상세 사이드정보 아이템 컴포넌트, 스토리북 추가

## 🔧 변경 사항

- 전략상세 사이드정보 아이템 컴포넌트
- 스토리북 추가

## 📸 스크린샷 (권장)

> 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 🙏 리뷰 참고 (선택 사항)

> 개발 과정에서 다른 분들의 의견이 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요.

## 📄 기타 (선택 사항)

> 그 외 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
