### PR TITLE
[Feat] 트레이더 리스트 카드 컴포넌트 구현

### DIFF
--- a/shared/ui/traders-list-card/index.tsx
+++ b/shared/ui/traders-list-card/index.tsx
@@ -1,0 +1,45 @@
+import classNames from 'classnames/bind'
+
+import Avatar from '@/shared/ui/avatar'
+import { LinkButton } from '@/shared/ui/link-button'
+
+import styles from './styles.module.scss'
+
+const cx = classNames.bind(styles)
+
+interface Props {
+  name: string
+  profileImage?: string
+  strategy: number
+  subscribe: number
+  traderId: string
+}
+
+const TradersListCard = ({ name, profileImage, strategy, subscribe }: Props) => {
+  return (
+    <div className={cx('traders-list-card')}>
+      <div className={cx('contents')}>
+        <div className={cx('profile-name')}>{name}</div>
+        <div className={cx('avatar')}>
+          <Avatar src={profileImage} size="large" />
+        </div>
+        <div className={cx('information')}>
+          <div>전략 {strategy}개</div>
+          <div>구독 {subscribe}개</div>
+        </div>
+      </div>
+      <div className="link-button-wrapper">
+        <LinkButton
+          href={'${PATH.TRADERS}/${traderId}'}
+          size="medium"
+          className={cx('link-button')}
+          style={{ color: '#ff5f33' }}
+        >
+          전략 목록 상세보기
+        </LinkButton>
+      </div>
+    </div>
+  )
+}
+
+export default TradersListCard

--- a/shared/ui/traders-list-card/index.tsx
+++ b/shared/ui/traders-list-card/index.tsx
@@ -8,32 +8,40 @@ import styles from './styles.module.scss'
 const cx = classNames.bind(styles)
 
 interface Props {
-  name: string
+  nickname: string
   profileImage?: string
-  strategy: number
-  subscribe: number
+  strategyCount: number
+  subscriberCount: number
   traderId: string
 }
 
-const TradersListCard = ({ name, profileImage, strategy, subscribe }: Props) => {
+const TradersListCard = ({
+  nickname,
+  profileImage,
+  strategyCount,
+  subscriberCount,
+  traderId,
+}: Props) => {
   return (
     <div className={cx('traders-list-card')}>
       <div className={cx('contents')}>
-        <div className={cx('profile-name')}>{name}</div>
+        <div className={cx('trader-info')}>
+          <div className={cx('trader-nickname')}>{nickname}</div>
+          <div className={cx('count-info')}>
+            <div>전략 {strategyCount}개</div>
+            <div>구독 {subscriberCount}개</div>
+          </div>
+        </div>
         <div className={cx('avatar')}>
           <Avatar src={profileImage} size="large" />
-        </div>
-        <div className={cx('information')}>
-          <div>전략 {strategy}개</div>
-          <div>구독 {subscribe}개</div>
         </div>
       </div>
       <div className="link-button-wrapper">
         <LinkButton
           href={'${PATH.TRADERS}/${traderId}'}
           size="medium"
+          variant="filled"
           className={cx('link-button')}
-          style={{ color: '#ff5f33' }}
         >
           전략 목록 상세보기
         </LinkButton>

--- a/shared/ui/traders-list-card/styles.module.scss
+++ b/shared/ui/traders-list-card/styles.module.scss
@@ -1,52 +1,50 @@
 .traders-list-card {
+  display: flex;
+  flex-direction: column;
   background-color: $color-white;
   border-radius: 8px;
   width: 300px;
   height: 220px;
-  padding: 28px 25px;
-  display: flex;
-  flex-direction: column;
-  position: relative;
+  padding: 32px 25px;
 }
 
 .contents {
-  margin-bottom: 35px;
+  margin-bottom: 17px;
   display: flex;
-  flex-direction: column;
-  position: relative;
+  justify-content: space-between;
 }
 
-.profile-name {
-  @include typo-h3;
+.trader-info {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.trader-nickname {
+  @include typo-b2;
   font-weight: $text-semibold;
-  position: absolute;
-  margin-top: 5px;
 }
 
 .avatar {
-  position: absolute;
-  right: 0px;
+  justify-content: flex-end;
 }
 
-.information {
+.count-info {
   @include typo-b3;
   color: $color-gray-500;
-  font-weight: $text-semibold;
-  margin-top: 45px;
-  display: flex;
-  flex-direction: column;
+  margin-top: 36px;
 }
 
 .link-button-wrapper {
   display: flex;
   justify-content: center;
   width: 100%;
-  margin-top: auto;
 }
 
 .link-button {
   align-self: center;
   text-align: center;
-  border-color: $color-orange-600;
+  border-color: $color-gray-800;
   width: 100%;
+  max-height: 45px;
 }

--- a/shared/ui/traders-list-card/styles.module.scss
+++ b/shared/ui/traders-list-card/styles.module.scss
@@ -1,0 +1,52 @@
+.traders-list-card {
+  background-color: $color-white;
+  border-radius: 8px;
+  width: 300px;
+  height: 220px;
+  padding: 28px 25px;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.contents {
+  margin-bottom: 35px;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.profile-name {
+  @include typo-h3;
+  font-weight: $text-semibold;
+  position: absolute;
+  margin-top: 5px;
+}
+
+.avatar {
+  position: absolute;
+  right: 0px;
+}
+
+.information {
+  @include typo-b3;
+  color: $color-gray-500;
+  font-weight: $text-semibold;
+  margin-top: 45px;
+  display: flex;
+  flex-direction: column;
+}
+
+.link-button-wrapper {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  margin-top: auto;
+}
+
+.link-button {
+  align-self: center;
+  text-align: center;
+  border-color: $color-orange-600;
+  width: 100%;
+}

--- a/shared/ui/traders-list-card/traders-list-card.stories.tsx
+++ b/shared/ui/traders-list-card/traders-list-card.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import TradersListCard from './index'
+
+const meta = {
+  title: 'Components/TradersListCard',
+  component: TradersListCard,
+  parameters: {
+    layout: 'centered',
+    backgrounds: {
+      default: 'dark',
+      values: [
+        {
+          name: 'dark',
+          value: '#222222',
+        },
+      ],
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof TradersListCard>
+
+export default meta
+type StoryType = StoryObj<typeof meta>
+
+export const Default: StoryType = {
+  args: {
+    name: '고양이',
+    profileImage: 'https://lh3.googleusercontent.com/a/your-image-id',
+    strategy: 10,
+    subscribe: 10,
+    traderId: '1234',
+  },
+}

--- a/shared/ui/traders-list-card/traders-list-card.stories.tsx
+++ b/shared/ui/traders-list-card/traders-list-card.stories.tsx
@@ -25,10 +25,10 @@ type StoryType = StoryObj<typeof meta>
 
 export const Default: StoryType = {
   args: {
-    name: '고양이',
+    nickname: '고양이는야옹하고울지',
     profileImage: 'https://lh3.googleusercontent.com/a/your-image-id',
-    strategy: 10,
-    subscribe: 10,
+    strategyCount: 10,
+    subscriberCount: 10,
     traderId: '1234',
   },
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

![스크린샷 2024-11-20 오전 8 10 09](https://github.com/user-attachments/assets/40240bc7-bbdd-4a8f-9819-20d9fc17f697)
트레이더 목록 페이지에 들어가는 **트레이더 리스트 카드 컴포넌트**를 구현했습니다.

## 🔧 변경 사항

- [x] traders-list-card 폴더 생성
- [x] TradersListCard 스토리북 추가

## 📸 스크린샷 

![2024-11-208 13 40-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/0a82da92-1719-44b8-97e2-aa9231c1c0d1)

## 🙏 리뷰 참고 

> **LinkButton 색상 설정 문제:** LinkButton의 텍스트 색상이 `color:$color-orange-600 `변수가 적용되지 않아 style을 사용해 색상을 직접 지정했습니다. 혹시 해결 방법에 대해 아신다면 조언 부탁드립니다. 

그리고 컴포넌트 구조나 Props 설계에 대한 추가 피드백이 있다면 말씀해 주세요!
_(커밋 단위 좀 더 세분화했어야 했는데 그러지 못한 점 사과드립니다..)_

### 2024/11/21(목) Issue
디자인 변경사항(버튼색상과 nickname 폰트크기 16px으로 변경)과 코드리뷰 반영해서 수정했습니다!

<img width="575" alt="스크린샷 2024-11-22 오전 1 54 57" src="https://github.com/user-attachments/assets/6ca26db3-83f8-4ecb-a9bf-1b5ae6ae4529">
