### PR TITLE
[Feat] 랜딩 페이지 Hero, UserMetrics 섹션 퍼블리싱

### DIFF
--- a/app/(landing)/(home)/_ui/hero-section/index.tsx
+++ b/app/(landing)/(home)/_ui/hero-section/index.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import Logo from '@/public/images/logo.svg'
+import classNames from 'classnames/bind'
+
+import { PATH } from '@/shared/constants/path'
+import { LinkButton } from '@/shared/ui/link-button'
+
+import styles from './styles.module.scss'
+
+const cx = classNames.bind(styles)
+
+const HeroSection = () => {
+  return (
+    <section className={cx('section')}>
+      <h1 className={cx('title')}>
+        성공적인 투자 전략을
+        <br />
+        참고하거나 공유하고 싶다면
+        <br />
+        <Logo className={cx('logo')} width="65" height="39" /> 인베스트메틱에서!
+      </h1>
+      <LinkButton href={PATH.SIGN_UP_USER_TYPE} variant="filled" className={cx('button')}>
+        바로 함께하기
+      </LinkButton>
+    </section>
+  )
+}
+
+export default HeroSection

--- a/app/(landing)/(home)/_ui/hero-section/styles.module.scss
+++ b/app/(landing)/(home)/_ui/hero-section/styles.module.scss
@@ -1,0 +1,19 @@
+.section {
+  text-align: center;
+}
+
+.title {
+  @include typo-h1;
+  padding-top: 100px;
+  color: $color-gray-800;
+}
+
+.logo {
+  display: inline-block;
+  width: 65px;
+  height: auto;
+}
+
+.button {
+  margin-top: 77px;
+}

--- a/app/(landing)/(home)/_ui/home-subtitle/index.tsx
+++ b/app/(landing)/(home)/_ui/home-subtitle/index.tsx
@@ -1,0 +1,15 @@
+import classNames from 'classnames/bind'
+
+import styles from './styles.module.scss'
+
+const cx = classNames.bind(styles)
+
+interface Props {
+  children: React.ReactNode
+}
+
+const HomeSubtitle = ({ children }: Props) => {
+  return <h2 className={cx('subtitle')}>{children}</h2>
+}
+
+export default HomeSubtitle

--- a/app/(landing)/(home)/_ui/home-subtitle/styles.module.scss
+++ b/app/(landing)/(home)/_ui/home-subtitle/styles.module.scss
@@ -1,0 +1,7 @@
+.subtitle {
+  margin-top: 120px;
+  @include typo-h4;
+  color: $color-gray-600;
+  font-weight: $text-bold;
+  text-align: center;
+}

--- a/app/(landing)/(home)/_ui/metric-card/index.tsx
+++ b/app/(landing)/(home)/_ui/metric-card/index.tsx
@@ -1,0 +1,21 @@
+import classNames from 'classnames/bind'
+
+import styles from './styles.module.scss'
+
+const cx = classNames.bind(styles)
+
+interface Props {
+  count: number
+  label: string
+}
+
+const MetricCard = ({ count, label }: Props) => {
+  return (
+    <div className={cx('container')}>
+      <strong className={cx('count')}>{count.toLocaleString()}</strong>
+      <p className={cx('label')}>{label}</p>
+    </div>
+  )
+}
+
+export default MetricCard

--- a/app/(landing)/(home)/_ui/metric-card/styles.module.scss
+++ b/app/(landing)/(home)/_ui/metric-card/styles.module.scss
@@ -1,0 +1,20 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 15px;
+  width: 300px;
+  height: 160px;
+  border-radius: 5px;
+  background-color: $color-white;
+}
+
+.count {
+  @include typo-h1;
+  color: $color-orange-500;
+}
+
+.label {
+  color: $color-gray-800;
+}

--- a/app/(landing)/(home)/_ui/user-metrics-section/index.tsx
+++ b/app/(landing)/(home)/_ui/user-metrics-section/index.tsx
@@ -1,0 +1,31 @@
+import classNames from 'classnames/bind'
+
+import HomeSubtitle from '../home-subtitle'
+import MetricCard from '../metric-card'
+import styles from './styles.module.scss'
+
+const cx = classNames.bind(styles)
+
+const UserMetricsSection = () => {
+  const { totalTraderCount, totalStrategiesCount, totalUserCount, totalSubscribeCount } = {
+    totalTraderCount: 512,
+    totalStrategiesCount: 5210,
+    totalUserCount: 43431,
+    totalSubscribeCount: 8210,
+  }
+
+  return (
+    <section>
+      <HomeSubtitle>이미 이렇게 많은 사람들이 주식 전략을 공유하고, 구독하고 있어요!</HomeSubtitle>
+
+      <div className={cx('card-wrapper')}>
+        <MetricCard count={totalTraderCount} label="명의 트레이더가" />
+        <MetricCard count={totalStrategiesCount} label="개의 투자 전략을 올렸어요!" />
+        <MetricCard count={totalUserCount} label="명의 투자자가" />
+        <MetricCard count={totalSubscribeCount} label="개의 전략을 구독 중이에요!" />
+      </div>
+    </section>
+  )
+}
+
+export default UserMetricsSection

--- a/app/(landing)/(home)/_ui/user-metrics-section/styles.module.scss
+++ b/app/(landing)/(home)/_ui/user-metrics-section/styles.module.scss
@@ -1,0 +1,6 @@
+.card-wrapper {
+  display: flex;
+  gap: 20px;
+  justify-content: center;
+  margin-top: 36px;
+}

--- a/app/(landing)/(home)/page.tsx
+++ b/app/(landing)/(home)/page.tsx
@@ -1,9 +1,11 @@
 import HeroSection from './_ui/hero-section'
+import UserMetricsSection from './_ui/user-metrics-section'
 
 const HomePage = () => {
   return (
     <>
       <HeroSection />
+      <UserMetricsSection />
     </>
   )
 }

--- a/app/(landing)/(home)/page.tsx
+++ b/app/(landing)/(home)/page.tsx
@@ -1,5 +1,11 @@
+import HeroSection from './_ui/hero-section'
+
 const HomePage = () => {
-  return <>Home</>
+  return (
+    <>
+      <HeroSection />
+    </>
+  )
 }
 
 export default HomePage

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -42,7 +42,14 @@ const nextConfig = {
     config.module.rules.push({
       test: /\.svg$/,
       issuer: /\.[jt]sx?$/,
-      use: ['@svgr/webpack'],
+      use: [
+        {
+          loader: '@svgr/webpack',
+          options: {
+            dimensions: false,
+          },
+        },
+      ],
     })
 
     return config

--- a/shared/ui/logo/styles.module.scss
+++ b/shared/ui/logo/styles.module.scss
@@ -4,11 +4,13 @@
   gap: 12px;
 
   svg {
+    width: 40px;
     flex-shrink: 0;
   }
 }
 
 .text {
+  width: 142px;
   color: $color-gray-500;
   line-height: normal;
 }

--- a/shared/ui/side-navigation/styles.module.scss
+++ b/shared/ui/side-navigation/styles.module.scss
@@ -29,7 +29,12 @@
   padding: 24px 0 0 24px;
 
   svg {
+    width: 40px;
     flex-shrink: 0;
+  }
+
+  .text {
+    width: 142px;
   }
 }
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

랜딩 페이지 Hero, UserMetrics 섹션 퍼블리싱 작업 했습니다!
원래 MSW까지 설정해서 올리려고 했는데 axios 설치 등.. 혹시모를 충돌 대비해서 일단 퍼블리싱 먼저 올립니다
퍼블리싱도 페이지 전체 진행한 후 올리려다가 Top 랭킹 섹션과 SM Score 섹션 컴포넌트 수정하면 변경사항이 너무 많아지고 복잡해질 것 같아서
Hero, UserMetrics 섹션까지만 PR 올렸습니다!

## 🔧 변경 사항

- svgr 설정 추가
    - 아이콘 사이즈 변경하려면 svg 파일에서 width, height를 지우는 등 번거로운 작업이 필요해서 설정을 추가해 해결했습니다
    - 🚨🚨아이콘 사용하실때 사이즈 지정 필수🚨🚨

## 📸 스크린샷 (권장)

![image](https://github.com/user-attachments/assets/bf687864-eee2-4ae7-8730-e718b40fab6e)

## 🙏 리뷰 참고 (선택 사항)

> 개발 과정에서 다른 분들의 의견이 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요.

## 📄 기타 (선택 사항)

- 헤더는 해석님이 로그인 페이지에서 적용해두셨다고 하셔서 따로 추가 안했습니다!
