### PR TITLE
[Refactor] 트레이더 리스트 카드 컴포넌트 코드 수정

### DIFF
--- a/shared/ui/traders-list-card/index.tsx
+++ b/shared/ui/traders-list-card/index.tsx
@@ -13,6 +13,7 @@ interface Props {
   strategyCount: number
   subscriberCount: number
   traderId: string
+  hasLinkButton?: boolean
 }
 
 const TradersListCard = ({
@@ -21,6 +22,7 @@ const TradersListCard = ({
   strategyCount,
   subscriberCount,
   traderId,
+  hasLinkButton = true,
 }: Props) => {
   return (
     <div className={cx('traders-list-card')}>
@@ -36,16 +38,18 @@ const TradersListCard = ({
           <Avatar src={profileImage} size="large" />
         </div>
       </div>
-      <div className="link-button-wrapper">
-        <LinkButton
-          href={'${PATH.TRADERS}/${traderId}'}
-          size="medium"
-          variant="filled"
-          className={cx('link-button')}
-        >
-          전략 목록 상세보기
-        </LinkButton>
-      </div>
+      {hasLinkButton && (
+        <div className="link-button-wrapper">
+          <LinkButton
+            href={'${PATH.TRADERS}/${traderId}'}
+            size="medium"
+            variant="filled"
+            className={cx('link-button')}
+          >
+            전략 목록 상세보기
+          </LinkButton>
+        </div>
+      )}
     </div>
   )
 }

--- a/shared/ui/traders-list-card/index.tsx
+++ b/shared/ui/traders-list-card/index.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames/bind'
 
+import { PATH } from '@/shared/constants/path'
 import Avatar from '@/shared/ui/avatar'
 import { LinkButton } from '@/shared/ui/link-button'
 
@@ -13,7 +14,7 @@ interface Props {
   strategyCount: number
   subscriberCount: number
   traderId: string
-  hasLinkButton?: boolean
+  hasButton?: boolean
 }
 
 const TradersListCard = ({
@@ -22,7 +23,7 @@ const TradersListCard = ({
   strategyCount,
   subscriberCount,
   traderId,
-  hasLinkButton = true,
+  hasButton = true,
 }: Props) => {
   return (
     <div className={cx('traders-list-card')}>
@@ -38,10 +39,10 @@ const TradersListCard = ({
           <Avatar src={profileImage} size="large" />
         </div>
       </div>
-      {hasLinkButton && (
+      {hasButton && (
         <div className="link-button-wrapper">
           <LinkButton
-            href={'${PATH.TRADERS}/${traderId}'}
+            href={`${PATH.TRADERS}/${traderId}`}
             size="medium"
             variant="filled"
             className={cx('link-button')}

--- a/shared/ui/traders-list-card/styles.module.scss
+++ b/shared/ui/traders-list-card/styles.module.scss
@@ -4,8 +4,7 @@
   background-color: $color-white;
   border-radius: 8px;
   width: 300px;
-  height: 220px;
-  padding: 32px 25px;
+  padding: 28px 28px;
 }
 
 .contents {

--- a/shared/ui/traders-list-card/traders-list-card.stories.tsx
+++ b/shared/ui/traders-list-card/traders-list-card.stories.tsx
@@ -40,6 +40,6 @@ export const WithoutButton: StoryType = {
     strategyCount: 10,
     subscriberCount: 10,
     traderId: '1234',
-    hasLinkButton: false,
+    hasButton: false,
   },
 }

--- a/shared/ui/traders-list-card/traders-list-card.stories.tsx
+++ b/shared/ui/traders-list-card/traders-list-card.stories.tsx
@@ -32,3 +32,14 @@ export const Default: StoryType = {
     traderId: '1234',
   },
 }
+
+export const WithoutButton: StoryType = {
+  args: {
+    nickname: '고양이는야옹하고울지',
+    profileImage: 'https://lh3.googleusercontent.com/a/your-image-id',
+    strategyCount: 10,
+    subscriberCount: 10,
+    traderId: '1234',
+    hasLinkButton: false,
+  },
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

트레이더 리스트 카드 컴포넌트 코드를 변경하고 SCSS를 수정했습니다.
기존에 컴포넌트 내부에 하드코딩되어 있던 링크 버튼을 props로 제어할 수 있도록 수정했습니다.

## 🔧 변경 사항

`hasLinkButton?: boolean` 속성을 추가하여 **링크 버튼의 표시 여부를 결정하도록 변경**했습니다.
기존에는 컴포넌트에 버튼이 고정되어 있었으나, `boolean`을 활용해 필요 시 표시하거나 생략할 수 있게 되었습니다.
추후 확장성을 고려하여 `children `속성을 사용하는 것도 고민했으나, 현재 디자인 상 해당 컴포넌트가 사용되는 페이지가 두 곳으로 한정적이기에 `boolean`으로 구현했습니다.

## 📸 스크린샷

![2024-11-236 36 05-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/cd15f8fa-1923-4bf6-ab1d-371c1281b0a1)

## 🙏 리뷰 참고

### `children vs boolean` 선택 이유
**장점:** `children`사용시 유연성이 커져 다양한 UI를 삽입 가능
**단점:** 부모 컴포넌트에서 사용하는 사람이 `children`으로 무엇을 넣어야 할지 명확하지 않아 오용 가능성이 생길 수 있음

현재 컴포넌트가 사용되는 곳이 제한적이고, 추가적인 유연성이 불필요한 상황이라 `boolean` 방식이 적합하다고 판단했습니다. 만약 컴포넌트 사용이 증가하거나 버튼 이외의 요소 추가가 요구된다면, `children`으로 변경하는 방안을 다시 검토하겠습니다😊