### PR TITLE
[fix] select 컴포넌트 option이 레이아웃에 영향을 끼치는 버그 수정 및 편의성 개선

### DIFF
--- a/shared/styles/base/_variables.scss
+++ b/shared/styles/base/_variables.scss
@@ -62,6 +62,7 @@ $breakpoint-xl: 1200px;
 $z-index: (
   modal: 1000,
   header: 100,
+  select: 10,
   base: 1,
   hidden: -1,
 );

--- a/shared/ui/dropdown/index.tsx
+++ b/shared/ui/dropdown/index.tsx
@@ -46,7 +46,7 @@ const Dropdown = ({
 
   return (
     <DropdownContext.Provider value={{ isOpen, toggleOpen, handleSelect }}>
-      <div className={cx(`dropdown-${size}`)} style={containerStyle} ref={dropdownRef}>
+      <div className={cx('dropdown', `dropdown-${size}`)} style={containerStyle} ref={dropdownRef}>
         <button
           onClick={toggleOpen}
           className={cx('container', 'trigger', size, { open: isOpen })}

--- a/shared/ui/dropdown/styles.module.scss
+++ b/shared/ui/dropdown/styles.module.scss
@@ -6,6 +6,10 @@ $large-height: 40px;
 $color-selected-text: #171717;
 
 .dropdown {
+  position: relative;
+}
+
+.dropdown {
   &-small {
     width: $small-width;
     height: fit-content;
@@ -29,6 +33,7 @@ $color-selected-text: #171717;
   svg {
     color: $color-gray-200;
     margin-left: auto;
+    width: 24px;
   }
 }
 
@@ -66,10 +71,13 @@ $color-selected-text: #171717;
 }
 
 .options {
+  position: absolute;
+  bottom: 0;
+  transform: translateY(calc(100% + 4px));
+  z-index: zIndex(select);
   list-style: none;
   height: fit-content;
   margin: 0;
-  margin-top: 4px;
   padding: 0;
   border-radius: 4px;
   background-color: $color-white;

--- a/shared/ui/dropdown/types.ts
+++ b/shared/ui/dropdown/types.ts
@@ -14,7 +14,7 @@ export interface DropdownProps {
   Trigger: ReactNode
   value: DropdownValueType
   onChange: (value: DropdownValueType) => void
-  isMultiple: boolean
+  isMultiple?: boolean
   containerStyle?: CSSProperties
   labelStyle?: CSSProperties
   children?: ReactNode


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

1. option의 position을 absolute로 주지 않아서 option이 열렸을 때 전체적인 레이아웃이 밀리는 버그를 해결했습니다.
2. isMultiple이 필수 옵션으로 지정되어있던 버그 해결했습니다.
3. select의 우측 아이콘 크기를 지정해주었습니다.
