### PR TITLE
[Feat] 전략 상세 상단 정보 컴포넌트 추가

### DIFF
--- a/app/(dashboard)/strategies/[strategyId]/_api/get-details-information.ts
+++ b/app/(dashboard)/strategies/[strategyId]/_api/get-details-information.ts
@@ -12,7 +12,7 @@ const getDetailsInformation = async (isReady: boolean, strategyId: string) => {
       return
     }
     const data = await response.data
-    const newDetailsData: InformationType[] = [
+    const detailsSideData: InformationType[] = [
       { title: '트레이더', data: data.nickname },
       { title: '최소 투자 금액', data: data.minimumInvestmentAmount },
       { title: '투자 원금', data: data.initialInvestment },
@@ -27,7 +27,25 @@ const getDetailsInformation = async (isReady: boolean, strategyId: string) => {
         { title: '등록일', data: data.createdAt },
       ],
     ]
-    return newDetailsData
+    const detailsInformationData = {
+      strategyId: data.strategyId,
+      strategyName: data.strategyName,
+      stockTypeIconURLs: data.stockTypeIconURLs,
+      tradeTypeIconURL: data.tradeTypeIconURL,
+      stockTypeNames: data.stockTypeNames,
+      tradeTypeName: data.tradeTypeName,
+      operationCycle: data.operationCycle,
+      strategyDescription: data.strategyDescription,
+      cumulativeProfitRate: data.cumulativeProfitRate,
+      maxDrawdownRate: data.maxDrawdownRate,
+      averageProfitLossRate: data.averageProfitLossRate,
+      profitFactor: data.profitFactor,
+      winRate: data.winRate,
+      subscriptionCount: data.subscriptionCount,
+      traderImgUrl: data.traderImgUrl,
+      subscribed: data.subscribed,
+    }
+    return { detailsSideData, detailsInformationData }
   } catch (err) {
     console.error(err)
   }

--- a/app/(dashboard)/strategies/[strategyId]/_hooks/query/use-get-details-information-data.ts
+++ b/app/(dashboard)/strategies/[strategyId]/_hooks/query/use-get-details-information-data.ts
@@ -1,13 +1,26 @@
 import { useQuery } from '@tanstack/react-query'
 
+import { StrategyDetailsInformationModel } from '@/shared/types/strategy-details-data'
+
 import getDetailsInformation from '../../_api/get-details-information'
+import { InformationType } from '../../page'
 
 interface Props {
   isReady: boolean
   strategyId: string
 }
 
-const useGetDetailsInformationData = ({ isReady, strategyId }: Props) => {
+const useGetDetailsInformationData = ({
+  isReady,
+  strategyId,
+}: Props): {
+  data:
+    | {
+        detailsSideData: InformationType[]
+        detailsInformationData: StrategyDetailsInformationModel
+      }
+    | undefined
+} => {
   return useQuery({
     queryKey: ['strategyDetails', strategyId],
     queryFn: () => getDetailsInformation(isReady, strategyId),

--- a/app/(dashboard)/strategies/[strategyId]/_ui/datails-information/index.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/datails-information/index.tsx
@@ -1,0 +1,49 @@
+import classNames from 'classnames/bind'
+
+import { StrategyDetailsInformationModel } from '@/shared/types/strategy-details-data'
+
+import StrategyIntroduction from '../introduction/index'
+import InvestInformation from './invest-information'
+import Percentage from './percentage'
+import StrategyNameBox from './strategy-name-box'
+import styles from './styles.module.scss'
+
+const cx = classNames.bind(styles)
+
+interface Props {
+  information: StrategyDetailsInformationModel
+}
+
+const DetailsInformation = ({ information }: Props) => {
+  const percentageToArray = [
+    { percent: information.cumulativeProfitRate, label: '누적 수익률' },
+    { percent: information.maxDrawdownRate, label: '최대 자본 인하율' },
+    { percent: information.averageProfitLossRate, label: '평균 손익률' },
+    { percent: information.profitFactor, label: 'Profit Factor' },
+    { percent: information.winRate, label: '승률' },
+  ]
+
+  return (
+    <>
+      <div className={cx('information-top')}>
+        <StrategyNameBox
+          iconUrl={[information.tradeTypeIconURL, ...information.stockTypeIconURLs]}
+          name={information.strategyName}
+        />
+        <InvestInformation
+          stock={information.stockTypeNames}
+          trade={information.tradeTypeName}
+          cycle={information.operationCycle}
+        />
+      </div>
+      <StrategyIntroduction content={information.strategyDescription} />
+      <div className={cx('percentage-container')}>
+        {percentageToArray.map((data) => (
+          <Percentage key={data.label} percent={data.percent} label={data.label} />
+        ))}
+      </div>
+    </>
+  )
+}
+
+export default DetailsInformation

--- a/app/(dashboard)/strategies/[strategyId]/_ui/datails-information/invest-information.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/datails-information/invest-information.tsx
@@ -1,0 +1,31 @@
+import classNames from 'classnames/bind'
+
+import styles from './styles.module.scss'
+
+const cx = classNames.bind(styles)
+
+interface Props {
+  stock: string[]
+  trade: string
+  cycle: string
+}
+
+const InvestInformation = ({ stock, trade, cycle }: Props) => {
+  const investData = [
+    { title: '투자 종목', data: stock.join(',') },
+    { title: '매매 유형', data: trade },
+    { title: '투자 주기', data: cycle },
+  ]
+  return (
+    <div className={cx('invest-container')}>
+      {investData.map((data, idx) => (
+        <div key={`${data}${idx}`} className={cx('info-item')}>
+          <p className={cx('invest-title')}>{data.title}</p>
+          <p className={cx('invest-data')}>{data.data}</p>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default InvestInformation

--- a/app/(dashboard)/strategies/[strategyId]/_ui/datails-information/percentage.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/datails-information/percentage.tsx
@@ -1,0 +1,26 @@
+import classNames from 'classnames/bind'
+
+import styles from './styles.module.scss'
+
+const cx = classNames.bind(styles)
+
+interface Props {
+  percent: number
+  label: string
+}
+
+const Percentage = ({ percent, label }: Props) => {
+  const isMinus = percent < 0
+
+  return (
+    <div className={cx('percentage-wrapper')}>
+      <p className={cx('percent', isMinus && 'minus')}>
+        {percent}
+        {label !== 'Profit Factor' && '%'}
+      </p>
+      <p className={cx('label')}>{label}</p>
+    </div>
+  )
+}
+
+export default Percentage

--- a/app/(dashboard)/strategies/[strategyId]/_ui/datails-information/strategy-name-box.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/datails-information/strategy-name-box.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+import StrategiesIcon from '@/app/(dashboard)/_ui/strategies-item/strategies-icon'
+import classNames from 'classnames/bind'
+
+import styles from './styles.module.scss'
+
+const cx = classNames.bind(styles)
+
+interface Props {
+  iconUrl: string[]
+  name: string
+  hasButton?: boolean
+}
+
+const StrategyNameBox = ({ iconUrl, name, hasButton = true }: Props) => {
+  return (
+    <div className={cx('name-container')}>
+      <StrategiesIcon icon={iconUrl} />
+      <p className={cx('name')}>{name}</p>
+      {hasButton && <button>제안서 다운로드</button>}
+    </div>
+  )
+}
+
+export default StrategyNameBox

--- a/app/(dashboard)/strategies/[strategyId]/_ui/datails-information/styles.module.scss
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/datails-information/styles.module.scss
@@ -1,0 +1,81 @@
+.information-top {
+  display: flex;
+  margin: 20px 0;
+  gap: 10px;
+}
+
+.name-container {
+  width: 30%;
+  height: 144px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border-radius: 5px;
+  background-color: $color-white;
+  .name {
+    @include typo-h4;
+  }
+  button {
+    height: 36px;
+    border-radius: 8px;
+    background-color: $color-gray-100;
+    color: $color-gray-700;
+  }
+}
+
+.invest-container {
+  width: 70%;
+  height: 144px;
+  display: flex;
+  gap: 20px;
+  padding: 30px;
+  border-radius: 5px;
+  background-color: $color-white;
+  .info-item {
+    width: 100%;
+    height: 100%;
+    border-right: 1px solid $color-gray-200;
+    &:last-child {
+      border-right: 0;
+    }
+    .invest-title {
+      @include typo-b1;
+      color: $color-gray-500;
+    }
+    .invest-data {
+      @include typo-b3;
+      color: $color-gray-700;
+      margin-top: 16px;
+    }
+  }
+}
+
+.percentage-container {
+  width: 100%;
+  display: flex;
+  gap: 10px;
+  margin: 20px 0;
+}
+.percentage-wrapper {
+  width: 20%;
+  height: 108px;
+  border-radius: 5px;
+  background-color: $color-white;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  .label {
+    @include typo-b2;
+    color: $color-gray-800;
+  }
+  .percent {
+    @include typo-h3;
+    color: #f53500;
+    &.minus {
+      color: #6877ff;
+    }
+  }
+}

--- a/app/(dashboard)/strategies/[strategyId]/_ui/review-container/review-list.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/review-container/review-list.tsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames/bind'
 
-import { fetchUser } from '@/shared/api/user'
 import Pagination from '@/shared/ui/pagination'
 
 import ReviewItem from './review-item'
@@ -29,8 +28,6 @@ interface Props {
 const ReviewList = ({ reviews, totalReview, currentPage, setCurrentPage }: Props) => {
   const handlePageChange = (page: number) => setCurrentPage(page)
 
-  const user = fetchUser()
-
   return (
     <>
       <ul className={cx('review-list')}>
@@ -42,7 +39,7 @@ const ReviewList = ({ reviews, totalReview, currentPage, setCurrentPage }: Props
             createdAt={review.createdAt}
             starRating={review.starRating}
             content={review.content}
-            isReviewer={user.nickname === review.nickname}
+            isReviewer={'' === review.nickname}
           />
         ))}
       </ul>

--- a/app/(dashboard)/strategies/[strategyId]/page.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/page.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import DetailsInformation from '@/app/(dashboard)/strategies/[strategyId]/_ui/datails-information'
+
 import { useMSWStore } from '@/shared/stores/msw'
 import BackHeader from '@/shared/ui/header/back-header'
 import Title from '@/shared/ui/title'
@@ -13,10 +15,12 @@ export type InformationType = { title: TitleType; data: string | number } | Info
 
 const StrategyDetailPage = ({ params }: { params: { strategyId: string } }) => {
   const isReady = useMSWStore((state) => state.isReady)
-  const { data: detailsSideData } = useGetDetailsInformationData({
+  const { data } = useGetDetailsInformationData({
     isReady,
     strategyId: params.strategyId,
   })
+
+  const { detailsSideData, detailsInformationData } = data || {}
 
   const hasDetailsSideData = detailsSideData?.map((data) => {
     if (!Array.isArray(data)) return data.data !== undefined
@@ -26,6 +30,7 @@ const StrategyDetailPage = ({ params }: { params: { strategyId: string } }) => {
     <div>
       <BackHeader label={'목록으로 돌아가기'} />
       <Title label={'전략 상세보기'} />
+      {detailsInformationData && <DetailsInformation information={detailsInformationData} />}
       <ReviewContainer strategyId={params.strategyId} />
       <SideContainer>
         {hasDetailsSideData?.[0] &&

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -1,4 +1,3 @@
-
 import {
   authHandlers,
   postHandlers,

--- a/shared/types/strategy-details-data.ts
+++ b/shared/types/strategy-details-data.ts
@@ -43,3 +43,22 @@ export interface StrategiesModel {
   averageRating: number
   totalReview: number
 }
+
+export interface StrategyDetailsInformationModel {
+  strategyId: string
+  strategyName: string
+  stockTypeIconURLs: string[]
+  tradeTypeIconURL: string
+  stockTypeNames: string[]
+  tradeTypeName: string
+  operationCycle: string
+  strategyDescription: string
+  cumulativeProfitRate: number
+  maxDrawdownRate: number
+  averageProfitLossRate: number
+  profitFactor: number
+  winRate: number
+  subscriptionCount: number
+  traderImgUrl: string
+  subscribed: boolean
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

전략 상세 상단 정보 컴포넌트 추가

## 🔧 변경 사항

- 사이드 정보, 상단정보 같은 api사용으로 api수정 및 데이터 타입 추가
- 전략 상세 상단 정보 컴포넌트 추가
- review getUser()삭제

## 📸 스크린샷 (권장)

![image](https://github.com/user-attachments/assets/5f663449-0cd1-492a-85d8-7a1b8da4808a)


## 🙏 리뷰 참고 (선택 사항)

> 개발 과정에서 다른 분들의 의견이 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요.

## 📄 기타 (선택 사항)

> 그 외 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
