### PR TITLE
[Feat] Input 에러메시지 컴포넌트 분리 및 ref속성 추가

### DIFF
--- a/shared/ui/error-messages/error-messages.stories.tsx
+++ b/shared/ui/error-messages/error-messages.stories.tsx
@@ -1,0 +1,33 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { ErrorMessages } from './index'
+
+const meta: Meta<typeof ErrorMessages> = {
+  title: 'Components/ErrorMessages',
+  component: ErrorMessages,
+  args: {
+    errorMessages: '에러메세지를 입력하세요.',
+  },
+  argTypes: {
+    errorMessages: {
+      control: 'text',
+      description: 'The error message to display.',
+      table: {
+        type: { summary: 'string | null' },
+      },
+    },
+  },
+  tags: ['autodocs'],
+}
+
+export default meta
+
+type StoryType = StoryObj<typeof ErrorMessages>
+
+export const Default: StoryType = {}
+
+export const EmptyMessage: StoryType = {
+  args: {
+    errorMessages: null,
+  },
+}

--- a/shared/ui/error-messages/index.tsx
+++ b/shared/ui/error-messages/index.tsx
@@ -5,8 +5,9 @@ import styles from './styles.module.scss'
 const cx = classNames.bind(styles)
 
 interface Props {
-  errorMessages?: string | null
+  errorMessages: string | null
+  isErr?: boolean
 }
-export const ErrorMessages = ({ errorMessages }: Props) => {
-  return <div>{errorMessages && <p className={cx('error-messages')}>{errorMessages}</p>}</div>
+export const ErrorMessages = ({ errorMessages, isErr = true }: Props) => {
+  return <>{isErr && <p className={cx('error-messages')}>{errorMessages}</p>}</>
 }

--- a/shared/ui/error-messages/index.tsx
+++ b/shared/ui/error-messages/index.tsx
@@ -1,0 +1,12 @@
+import classNames from 'classnames/bind'
+
+import styles from './styles.module.scss'
+
+const cx = classNames.bind(styles)
+
+interface Props {
+  errorMessages?: string | null
+}
+export const ErrorMessages = ({ errorMessages }: Props) => {
+  return <div>{errorMessages && <p className={cx('error-messages')}>{errorMessages}</p>}</div>
+}

--- a/shared/ui/error-messages/styles.module.scss
+++ b/shared/ui/error-messages/styles.module.scss
@@ -1,0 +1,5 @@
+.error-messages {
+  color: $color-orange-800;
+  font-size: $text-b3;
+  font-weight: $text-medium;
+}

--- a/shared/ui/input/index.tsx
+++ b/shared/ui/input/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ComponentProps } from 'react'
+import { ComponentPropsWithoutRef, forwardRef } from 'react'
 
 import classNames from 'classnames/bind'
 
@@ -10,30 +10,25 @@ const cx = classNames.bind(styles)
 
 export type InputSizeType = 'small' | 'medium' | 'large' | 'full'
 
-interface Props extends ComponentProps<'input'> {
+interface Props extends ComponentPropsWithoutRef<'input'> {
   inputSize?: InputSizeType
-  errorMessage?: string | null
+  error?: boolean
 }
 
-export const Input = ({
-  inputSize = 'medium',
-  errorMessage,
-  className,
-  value,
-  onChange,
-  ...props
-}: Props) => {
-  return (
-    <div>
-      <input
-        value={value}
-        onChange={onChange}
-        className={cx('input', inputSize, className, {
-          error: !!errorMessage,
-        })}
-        {...props}
-      />
-      {errorMessage && <p className={cx('error-message')}>{errorMessage}</p>}
-    </div>
-  )
-}
+export const Input = forwardRef<HTMLInputElement, Props>(
+  ({ inputSize = 'medium', className, value, error = false, onChange, ...props }, ref) => {
+    return (
+      <div>
+        <input
+          ref={ref}
+          value={value}
+          onChange={onChange}
+          className={cx('input', inputSize, { error }, className)}
+          {...props}
+        />
+      </div>
+    )
+  }
+)
+
+Input.displayName = 'Input'

--- a/shared/ui/input/input.stories.tsx
+++ b/shared/ui/input/input.stories.tsx
@@ -7,7 +7,6 @@ const meta: Meta<typeof Input> = {
   component: Input,
   args: {
     inputSize: 'medium',
-    errorMessage: null,
     placeholder: 'Enter text',
     type: 'text',
   },
@@ -19,16 +18,6 @@ const meta: Meta<typeof Input> = {
     type: {
       control: { type: 'select' },
       options: ['email', 'password', 'tel', 'text'],
-    },
-    errorMessage: {
-      control: { type: 'select' },
-      options: [
-        null,
-        '비밀번호는 8자리 이상, 문자와 숫자를 포함해야 합니다.',
-        '이메일 형식이 잘못되었습니다.',
-        '전화번호는 10자리 이상이어야 합니다.',
-        '필수 입력란입니다.',
-      ],
     },
   },
   tags: ['autodocs'],

--- a/shared/ui/input/styles.module.scss
+++ b/shared/ui/input/styles.module.scss
@@ -36,11 +36,3 @@
     cursor: not-allowed;
   }
 }
-
-.error-message {
-  color: $color-orange-700;
-  margin-top: 10px;
-  margin-bottom: 10px;
-  font-size: $text-b3;
-  font-weight: $text-medium;
-}

--- a/shared/ui/search-input/index.tsx
+++ b/shared/ui/search-input/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ComponentProps } from 'react'
+import { ComponentPropsWithoutRef, forwardRef } from 'react'
 
 import { SearchIcon } from '@/public/icons'
 import classNames from 'classnames/bind'
@@ -9,28 +9,27 @@ import styles from './styles.module.scss'
 
 const cx = classNames.bind(styles)
 
-interface Props extends ComponentProps<'input'> {
+interface Props extends ComponentPropsWithoutRef<'input'> {
   placeholder?: string
   handleSearchIconClick?: () => void
 }
 
-export const SearchInput = ({
-  placeholder = '',
-  handleSearchIconClick,
-  value,
-  onChange,
-  ...props
-}: Props) => {
-  return (
-    <div className={cx('search-input-container')}>
-      <input
-        value={value}
-        onChange={onChange}
-        placeholder={placeholder}
-        className={cx('search-input')}
-        {...props}
-      />
-      <SearchIcon className={cx('search-icon')} onClick={handleSearchIconClick} />
-    </div>
-  )
-}
+export const SearchInput = forwardRef<HTMLInputElement, Props>(
+  ({ placeholder = '', handleSearchIconClick, value, onChange, ...props }: Props, ref) => {
+    return (
+      <div className={cx('search-input-container')}>
+        <input
+          ref={ref}
+          value={value}
+          onChange={onChange}
+          placeholder={placeholder}
+          className={cx('search-input')}
+          {...props}
+        />
+        <SearchIcon className={cx('search-icon')} onClick={handleSearchIconClick} />
+      </div>
+    )
+  }
+)
+
+SearchInput.displayName = 'SearchInput'


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

기존 `Input`컴포넌트 내부에 포함되어 있던 에러 메시지 로직 `ErrorMessages` 컴포넌트 분리
`Input` 컴포넌트에 `ref` 속성을 적용하여 외부에서 DOM 요소에 직접 접근할 수 있도록 기능 확장

## 🔧 변경 사항

`ErrorMessages` 컴포넌트 분리
`Input` 컴포넌트 개선: `React.forwardRef`를 사용하여 `ref` 속성을 지원.

## 📸 스크린샷 

![2024-11-269 35 27-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/80f9c98e-d3a9-47ea-8dfc-5096b8ccfa65)

## 🙏 리뷰 참고 

기존 `ComponentProps`를 `ComponentPropsWithoutRef<'input'>`로 변경하여 기본 <input> 속성을 포함시켰습니다.
장점으로는

1. 자동으로 props 타입 가져오기:
<input> 태그에서 기본적으로 지원하는 props(예: value, onChange, type, placeholder 등)를 일일이 정의하지 않아도 됩니다.
ComponentPropsWithoutRef<'input'>를 사용하면 이런 props를 자동으로 타입으로 설정합니다.

2. ref와의 충돌 방지: 
ref는 리액트 컴포넌트에서 특별히 처리해야 합니다.
ComponentPropsWithoutRef<'input'>는 기본 props에서 ref를 제외하므로, forwardRef와 함께 사용할 때 타입 충돌을 방지할 수 있습니다.

라고 하는데 ref 속성 적용은 이번이 두 번째라 많이 부족합니다.. 불필요한 코드가 있을 시 말씀해 주시면 감사하겠습니다.

```ts
// Input ref 속성 활용 예시

import { useRef } from 'react';
import { Input } from './Input';

const MyComponent = () => {
  const inputRef = useRef<HTMLInputElement>(null);

  const focusInput = () => {
    inputRef.current?.focus(); // Input 요소에 포커스
  };

  return (
    <div>
      <Input ref={inputRef} placeholder="아무말대잔치" inputSize="medium" />
      <button onClick={focusInput}>Focus Input</button>
    </div>
  );
};

export default MyComponent;
```

### 2024/11/27 Issue

**`SearchInput` 컴포넌트에도 ref 속성 적용해놓았습니다.**

```ts
// SearchInput ref 속성 활용 예시

const searchInputRef = useRef<HTMLInputElement>(null)

<SearchInput 
  ref={searchInputRef} 
  placeholder="아무말대잔치"
  onChange={handleSearchChange} 
  value={searchValue}
/>
```