### PR TITLE
[Feat] 트레이더 상세보기 페이지 퍼블리싱

### DIFF
--- a/app/(dashboard)/traders/[traderId]/page.module.scss
+++ b/app/(dashboard)/traders/[traderId]/page.module.scss
@@ -1,0 +1,11 @@
+.page-container {
+  padding: 0 15px;
+}
+
+.title {
+  margin-bottom: 48px;
+}
+
+.card-wrapper {
+  margin-bottom: 54px;
+}

--- a/app/(dashboard)/traders/[traderId]/page.tsx
+++ b/app/(dashboard)/traders/[traderId]/page.tsx
@@ -1,5 +1,83 @@
+'use client'
+
+import styles from '@/app/(dashboard)/traders/[traderId]/page.module.scss'
+import classNames from 'classnames/bind'
+
+import BackHeader from '@/shared/ui/header/back-header'
+import Title from '@/shared/ui/title'
+import TradersListCard from '@/shared/ui/traders-list-card'
+
+import ListHeader from '../../_ui/list-header'
+import StrategiesItem from '../../_ui/strategies-item'
+
+const cx = classNames.bind(styles)
+
 const TraderDetailPage = () => {
-  return <></>
+  // TODO: 임시데이터 제거
+  const strategiesModel = {
+    strategyId: '123',
+    strategyName: '리치테크 FuturesDay',
+    nickname: 'MACS',
+    stockTypeIconUrl: [],
+    stockTypeNames: [],
+    profitRateChartData: {
+      xAxis: [
+        '2023-01-01',
+        '2023-01-02',
+        '2023-01-03',
+        '2023-01-04',
+        '2023-01-05',
+        '2023-01-06',
+        '2023-01-07',
+        '2023-01-08',
+        '2023-01-09',
+      ],
+      yAxis: [7.2, 5.2, 25, 12.8, 17.2, 11.4, 20, 16, 18],
+    },
+    tradeTypeIconUrl: '',
+    tradeTypeName: '',
+    mdd: '-20,580,856',
+    smScore: 60.6,
+    cumulativeProfitLossRate: 120.1,
+    recentYearProfitLossRate: 30.1,
+    subscriptionCnt: 23,
+    isSubscribed: true,
+    averageRating: 4.8,
+    totalReview: 12,
+  }
+
+  const traderData = {
+    nickname: '냥냥펀치',
+    strategyCount: 10,
+    subscriberCount: 20,
+    traderId: '940504',
+  }
+
+  return (
+    <>
+      <div className={cx('page-container')}>
+        <BackHeader label={'목록으로 돌아가기'} />
+        <div className={cx('title')}>
+          <Title label={'트레이더 상세보기'}></Title>
+        </div>
+        <div className={cx('card-wrapper')}>
+          <TradersListCard
+            key={traderData.traderId}
+            nickname={traderData.nickname}
+            strategyCount={traderData.strategyCount}
+            subscriberCount={traderData.subscriberCount}
+            traderId={traderData.traderId}
+          />
+        </div>
+        <ListHeader></ListHeader>
+        {Array(3)
+          .fill(strategiesModel)
+          .map((item, index) => (
+            <StrategiesItem key={index} strategiesData={item} />
+          ))}
+      </div>
+    </>
+  )
 }
 
 export default TraderDetailPage

--- a/app/(dashboard)/traders/[traderId]/page.tsx
+++ b/app/(dashboard)/traders/[traderId]/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import styles from '@/app/(dashboard)/traders/[traderId]/page.module.scss'
 import classNames from 'classnames/bind'
 
 import BackHeader from '@/shared/ui/header/back-header'
@@ -9,6 +8,7 @@ import TradersListCard from '@/shared/ui/traders-list-card'
 
 import ListHeader from '../../_ui/list-header'
 import StrategiesItem from '../../_ui/strategies-item'
+import styles from './page.module.scss'
 
 const cx = classNames.bind(styles)
 
@@ -67,9 +67,10 @@ const TraderDetailPage = () => {
             strategyCount={traderData.strategyCount}
             subscriberCount={traderData.subscriberCount}
             traderId={traderData.traderId}
+            hasButton={false}
           />
         </div>
-        <ListHeader></ListHeader>
+        <ListHeader />
         {Array(3)
           .fill(strategiesModel)
           .map((item, index) => (


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

**1. 트레이더 상세보기 페이지 레이아웃 구현**
`BackHeader`를 사용하여 상단에 '목록으로 돌아가기' 버튼 추가.
페이지 타이틀은 `Title`컴포넌트를 활용해 '트레이더 상세보기'로 표시.
트레이더 정보를 표시하기 위해 `TradersListCard` 컴포넌트 렌더링.

**2. 전략 정보 리스트**
`ListHeader`를 추가하여 전략 목록 상단에 헤더 구성.
더미 데이터를 기반으로 `StrategiesItem` 컴포넌트를 3회 반복 렌더링.

**3. 임시 데이터 활용**
API 연동을 위해 더미 데이터를 임시적으로 사용했고 추후, 연동 후 데이터 모델을 실제 API 데이터로 교체 예정입니다.

## 📸 스크린샷 

![2024-11-271 49 40-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/7402058f-ef04-424e-8f26-1b8263b156f3)