### PR TITLE
[Feat] 문의내역 페이지 퍼블리싱

### DIFF
--- a/app/(dashboard)/my/questions/_ui/question-card/index.tsx
+++ b/app/(dashboard)/my/questions/_ui/question-card/index.tsx
@@ -1,5 +1,8 @@
+import Link from 'next/link'
+
 import classNames from 'classnames/bind'
 
+import { PATH } from '@/shared/constants/path'
 import type { QuestionStatusType } from '@/shared/types/questions'
 import Avatar from '@/shared/ui/avatar'
 import Label from '@/shared/ui/label'
@@ -17,12 +20,14 @@ export interface QuestionCardProps {
 }
 
 interface Props extends QuestionCardProps {
+  qnaId: number
   strategyName: string
   title: string
   status: QuestionStatusType
 }
 
 const QuestionCard = ({
+  qnaId,
   strategyName,
   title,
   contents,
@@ -33,19 +38,21 @@ const QuestionCard = ({
 }: Props) => {
   return (
     <div className={cx('card-container')}>
-      <div className={cx('top-wrapper')}>
-        <strong className={cx('strategy-name')}>{strategyName}</strong>
-        <span className={cx('created-at')}>{formatDateTime(createdAt)}</span>
-      </div>
-      <h2 className={cx('title')}>{title}</h2>
-      <p className={cx('contents')}>{contents}</p>
-      <div className={cx('bottom-wrapper')}>
-        <div className={cx('avatar-wrapper')}>
-          <Avatar src={profileImage} size="medium" />
-          <span>{nickname}</span>
+      <Link href={`${PATH.MY_QUESTIONS}/${qnaId}`}>
+        <div className={cx('top-wrapper')}>
+          <strong className={cx('strategy-name')}>{strategyName}</strong>
+          <span className={cx('created-at')}>{formatDateTime(createdAt)}</span>
         </div>
-        <Label color={status === '답변 완료' ? 'indigo' : 'orange'}>{status}</Label>
-      </div>
+        <h2 className={cx('title')}>{title}</h2>
+        <p className={cx('contents')}>{contents}</p>
+        <div className={cx('bottom-wrapper')}>
+          <div className={cx('avatar-wrapper')}>
+            <Avatar src={profileImage} size="medium" />
+            <span>{nickname}</span>
+          </div>
+          <Label color={status === '답변 완료' ? 'indigo' : 'orange'}>{status}</Label>
+        </div>
+      </Link>
     </div>
   )
 }

--- a/app/(dashboard)/my/questions/_ui/questions-tab-content/index.tsx
+++ b/app/(dashboard)/my/questions/_ui/questions-tab-content/index.tsx
@@ -1,0 +1,128 @@
+import classNames from 'classnames/bind'
+
+import { PATH } from '@/shared/constants/path'
+import { usePagination } from '@/shared/hooks/custom/use-pagination'
+import { QuestionModel } from '@/shared/types/questions'
+import Pagination from '@/shared/ui/pagination'
+
+import QuestionCard from '../question-card'
+import styles from './styles.module.scss'
+
+const cx = classNames.bind(styles)
+
+const COUNT_PER_PAGE = 4
+
+type QuestionTabType = 'all' | 'waiting' | 'complete'
+
+interface Props {
+  options: QuestionTabType
+}
+
+const QuestionsTabContent = ({ options }: Props) => {
+  const { page, handlePageChange } = usePagination({
+    basePath: PATH.MY_QUESTIONS,
+    pageSize: COUNT_PER_PAGE,
+  })
+  // TODO: options에 따른 questions 데이터 불러오기
+  // 검색 조건 등 추가될 수 있어서 option 대신 options로 사용
+
+  // 임시
+  const totalPages = 2
+
+  const questionsData: QuestionModel[] = [
+    {
+      qnaId: 1,
+      userId: 101,
+      strategyId: 1,
+      title: 'Dynamic ETF 전략 진입 시점 문의드립니다',
+      questionContent:
+        '현재 시장 상황에서 Dynamic ETF 전략을 시작하려고 하는데, 적절한 진입 시점인지 고민됩니다. MDD 관리는 어떻게 하시는지도 궁금합니다.',
+      status: '답변 완료',
+      strategyName: 'Dynamic ETF 전략',
+      createdAt: '2024-03-15T09:30:00Z',
+      profileImageUrl: '/images/profile1.png',
+      nickname: '투자초보123',
+    },
+    {
+      qnaId: 2,
+      userId: 102,
+      strategyId: 6,
+      title: 'Active LongShort 전략 레버리지 문의',
+      questionContent:
+        'Active LongShort 전략에서 사용하시는 레버리지 비율이 궁금합니다. 리스크 관리는 어떻게 하시나요?',
+      status: '답변 대기',
+      strategyName: 'Active LongShort',
+      createdAt: '2024-03-14T15:45:00Z',
+      profileImageUrl: '/images/profile2.png',
+      nickname: '실전투자자',
+    },
+    {
+      qnaId: 3,
+      userId: 103,
+      strategyId: 3,
+      title: 'Futures Pro 전략 업데이트 일정',
+      questionContent:
+        '다음 전략 업데이트 일정이 궁금합니다. 현재 수익률이 조금 정체되어 있는 것 같은데 어떻게 보시나요?',
+      status: '답변 완료',
+      strategyName: 'Futures Pro',
+      createdAt: '2024-03-13T11:20:00Z',
+      profileImageUrl: '/images/profile3.png',
+      nickname: '퓨처스마스터',
+    },
+    {
+      qnaId: 4,
+      userId: 104,
+      strategyId: 8,
+      title: 'High Risk High Return 전략 백테스트 결과 문의',
+      questionContent:
+        '백테스트 기간과 구체적인 결과가 궁금합니다. 특히 2023년 변동성 장세에서의 성과는 어땠나요?',
+      status: '답변 완료',
+      strategyName: 'High Risk High Return',
+      createdAt: '2024-03-12T16:15:00Z',
+      profileImageUrl: '/images/profile4.png',
+      nickname: '데이터분석가',
+    },
+    {
+      qnaId: 5,
+      userId: 105,
+      strategyId: 2,
+      title: '고수익 ETF 전략 종목 선정 기준',
+      questionContent:
+        'ETF 선정 기준과 리밸런싱 주기가 궁금합니다. 또한 현재 포트폴리오에서 가장 비중이 높은 ETF는 무엇인가요?',
+      status: '답변 대기',
+      strategyName: '고수익 ETF',
+      createdAt: '2024-03-11T13:50:00Z',
+      profileImageUrl: '/images/profile5.png',
+      nickname: 'ETF러버',
+    },
+  ]
+
+  return (
+    <>
+      <ul className={cx('question-list')}>
+        {questionsData &&
+          questionsData.length &&
+          questionsData.map((question) => (
+            <li key={question.qnaId}>
+              <QuestionCard
+                qnaId={question.qnaId}
+                strategyName={question.strategyName}
+                title={question.title}
+                status={question.status}
+                contents={question.questionContent}
+                nickname={question.nickname}
+                createdAt={question.createdAt}
+              />
+            </li>
+          ))}
+      </ul>
+      {!questionsData ||
+        (!questionsData.length && <p className={cx('empty-message')}>문의 내역이 없습니다.</p>)}
+      <div className={cx('pagination-wrapper')}>
+        <Pagination currentPage={page} maxPage={totalPages} onPageChange={handlePageChange} />
+      </div>
+    </>
+  )
+}
+
+export default QuestionsTabContent

--- a/app/(dashboard)/my/questions/_ui/questions-tab-content/index.tsx
+++ b/app/(dashboard)/my/questions/_ui/questions-tab-content/index.tsx
@@ -1,5 +1,3 @@
-import { Suspense } from 'react'
-
 import classNames from 'classnames/bind'
 
 import { PATH } from '@/shared/constants/path'
@@ -101,25 +99,24 @@ const QuestionsTabContent = ({ options }: Props) => {
 
   return (
     <>
-      <Suspense>
-        <ul className={cx('question-list')}>
-          {questionsData &&
-            questionsData.length &&
-            questionsData.map((question) => (
-              <li key={question.qnaId}>
-                <QuestionCard
-                  qnaId={question.qnaId}
-                  strategyName={question.strategyName}
-                  title={question.title}
-                  status={question.status}
-                  contents={question.questionContent}
-                  nickname={question.nickname}
-                  createdAt={question.createdAt}
-                />
-              </li>
-            ))}
-        </ul>
-      </Suspense>
+      <ul className={cx('question-list')}>
+        {questionsData &&
+          questionsData.length &&
+          questionsData.map((question) => (
+            <li key={question.qnaId}>
+              <QuestionCard
+                qnaId={question.qnaId}
+                strategyName={question.strategyName}
+                title={question.title}
+                status={question.status}
+                contents={question.questionContent}
+                nickname={question.nickname}
+                createdAt={question.createdAt}
+              />
+            </li>
+          ))}
+      </ul>
+
       {!questionsData ||
         (!questionsData.length && <p className={cx('empty-message')}>문의 내역이 없습니다.</p>)}
       <div className={cx('pagination-wrapper')}>

--- a/app/(dashboard)/my/questions/_ui/questions-tab-content/index.tsx
+++ b/app/(dashboard)/my/questions/_ui/questions-tab-content/index.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from 'react'
+
 import classNames from 'classnames/bind'
 
 import { PATH } from '@/shared/constants/path'
@@ -99,23 +101,25 @@ const QuestionsTabContent = ({ options }: Props) => {
 
   return (
     <>
-      <ul className={cx('question-list')}>
-        {questionsData &&
-          questionsData.length &&
-          questionsData.map((question) => (
-            <li key={question.qnaId}>
-              <QuestionCard
-                qnaId={question.qnaId}
-                strategyName={question.strategyName}
-                title={question.title}
-                status={question.status}
-                contents={question.questionContent}
-                nickname={question.nickname}
-                createdAt={question.createdAt}
-              />
-            </li>
-          ))}
-      </ul>
+      <Suspense>
+        <ul className={cx('question-list')}>
+          {questionsData &&
+            questionsData.length &&
+            questionsData.map((question) => (
+              <li key={question.qnaId}>
+                <QuestionCard
+                  qnaId={question.qnaId}
+                  strategyName={question.strategyName}
+                  title={question.title}
+                  status={question.status}
+                  contents={question.questionContent}
+                  nickname={question.nickname}
+                  createdAt={question.createdAt}
+                />
+              </li>
+            ))}
+        </ul>
+      </Suspense>
       {!questionsData ||
         (!questionsData.length && <p className={cx('empty-message')}>문의 내역이 없습니다.</p>)}
       <div className={cx('pagination-wrapper')}>

--- a/app/(dashboard)/my/questions/_ui/questions-tab-content/styles.module.scss
+++ b/app/(dashboard)/my/questions/_ui/questions-tab-content/styles.module.scss
@@ -1,0 +1,16 @@
+.question-list {
+  padding-top: 24px;
+
+  li {
+    margin-bottom: 24px;
+  }
+}
+
+.empty-message {
+  margin: 12px 0;
+  @include typo-b2;
+}
+
+.pagination-wrapper {
+  margin-bottom: 24px;
+}

--- a/app/(dashboard)/my/questions/_ui/questions-tab/index.tsx
+++ b/app/(dashboard)/my/questions/_ui/questions-tab/index.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useState } from 'react'
+
+import Tabs from '@/shared/ui/tabs'
+
+import QuestionsTabContent from '../questions-tab-content'
+
+const QuestionsTab = () => {
+  const [activeTab, setActiveTab] = useState('all')
+
+  const TABS = [
+    {
+      id: 'all',
+      label: '모든 질문',
+      content: <QuestionsTabContent options="all" />,
+    },
+    {
+      id: 'waiting',
+      label: '답변 대기',
+      content: <QuestionsTabContent options="waiting" />,
+    },
+    {
+      id: 'complete',
+      label: '답변 완료',
+      content: <QuestionsTabContent options="complete" />,
+    },
+  ]
+
+  return <Tabs activeTab={activeTab} onTabChange={setActiveTab} tabs={TABS} />
+}
+
+export default QuestionsTab

--- a/app/(dashboard)/my/questions/_ui/questions-tab/index.tsx
+++ b/app/(dashboard)/my/questions/_ui/questions-tab/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { Suspense, useState } from 'react'
 
 import Tabs from '@/shared/ui/tabs'
 
@@ -13,17 +13,29 @@ const QuestionsTab = () => {
     {
       id: 'all',
       label: '모든 질문',
-      content: <QuestionsTabContent options="all" />,
+      content: (
+        <Suspense>
+          <QuestionsTabContent options="all" />
+        </Suspense>
+      ),
     },
     {
       id: 'waiting',
       label: '답변 대기',
-      content: <QuestionsTabContent options="waiting" />,
+      content: (
+        <Suspense>
+          <QuestionsTabContent options="waiting" />
+        </Suspense>
+      ),
     },
     {
       id: 'complete',
       label: '답변 완료',
-      content: <QuestionsTabContent options="complete" />,
+      content: (
+        <Suspense>
+          <QuestionsTabContent options="complete" />
+        </Suspense>
+      ),
     },
   ]
 

--- a/app/(dashboard)/my/questions/page.module.scss
+++ b/app/(dashboard)/my/questions/page.module.scss
@@ -1,0 +1,12 @@
+.title-wrapper {
+  margin: 80px 0 32px;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.search-wrapper {
+  display: flex;
+  gap: 24px;
+}

--- a/app/(dashboard)/my/questions/page.tsx
+++ b/app/(dashboard)/my/questions/page.tsx
@@ -1,5 +1,59 @@
+'use client'
+
+import { useState } from 'react'
+
+import classNames from 'classnames/bind'
+
+import { DropdownValueType } from '@/shared/ui/dropdown/types'
+import { SearchInput } from '@/shared/ui/search-input'
+import Select from '@/shared/ui/select'
+import Title from '@/shared/ui/title'
+
+import QuestionsTab from './_ui/questions-tab'
+import styles from './page.module.scss'
+
+const cx = classNames.bind(styles)
+
+const searchSelectOptions = [
+  {
+    value: 'all',
+    label: '전체',
+  },
+  {
+    value: 'trader',
+    label: '트레이더',
+  },
+  {
+    value: 'title',
+    label: '제목',
+  },
+  {
+    value: 'strategy',
+    label: '전략명',
+  },
+]
+
 const MyQuestionsPage = () => {
-  return <></>
+  const [selectedOption, setSelectedOption] = useState<DropdownValueType>('최신순')
+
+  return (
+    <div className={cx('container')}>
+      <div className={cx('title-wrapper')}>
+        <Title label="문의 내역" />
+        <div className={cx('search-wrapper')}>
+          <Select
+            size="small"
+            value={selectedOption}
+            placeholder="검색 조건"
+            onChange={setSelectedOption}
+            options={searchSelectOptions}
+          />
+          <SearchInput />
+        </div>
+      </div>
+      <QuestionsTab />
+    </div>
+  )
 }
 
 export default MyQuestionsPage

--- a/shared/types/questions.ts
+++ b/shared/types/questions.ts
@@ -1,1 +1,14 @@
 export type QuestionStatusType = '답변 대기' | '답변 완료'
+
+export interface QuestionModel {
+  qnaId: number
+  userId: number
+  strategyId: number
+  title: string
+  questionContent: string
+  status: QuestionStatusType
+  strategyName: string
+  createdAt: string
+  profileImageUrl: string
+  nickname: string
+}

--- a/shared/ui/search-input/index.tsx
+++ b/shared/ui/search-input/index.tsx
@@ -11,11 +11,11 @@ const cx = classNames.bind(styles)
 
 interface Props extends ComponentPropsWithoutRef<'input'> {
   placeholder?: string
-  handleSearchIconClick?: () => void
+  onSearchIconClick?: () => void
 }
 
 export const SearchInput = forwardRef<HTMLInputElement, Props>(
-  ({ placeholder = '', handleSearchIconClick, value, onChange, ...props }: Props, ref) => {
+  ({ placeholder = '', onSearchIconClick, value, onChange, ...props }: Props, ref) => {
     return (
       <div className={cx('search-input-container')}>
         <input
@@ -26,7 +26,7 @@ export const SearchInput = forwardRef<HTMLInputElement, Props>(
           className={cx('search-input')}
           {...props}
         />
-        <SearchIcon className={cx('search-icon')} onClick={handleSearchIconClick} />
+        <SearchIcon className={cx('search-icon')} onClick={onSearchIconClick} />
       </div>
     )
   }

--- a/shared/ui/search-input/search-input.stories.tsx
+++ b/shared/ui/search-input/search-input.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof SearchInput> = {
     placeholder: 'Search...',
   },
   argTypes: {
-    handleSearchIconClick: { action: 'clicked' },
+    onSearchIconClick: { action: 'clicked' },
   },
   tags: ['autodocs'],
 }

--- a/shared/ui/search-input/styles.module.scss
+++ b/shared/ui/search-input/styles.module.scss
@@ -31,6 +31,7 @@
   right: 12px;
   top: 50%;
   transform: translateY(-50%);
+  width: 24px;
   color: $color-gray-500;
   cursor: pointer;
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

문의 내역 api가 아직 작업 진행중이고 확정이 되지 않은 상태라 일단 더미데이터로 퍼블리싱만 먼저 작업했습니다!
api 나오고 나면 구조는 좀 바뀔 것 같아요...

## 🔧 변경 사항

- SearchInput의 handleSearchIconClick을 컨벤션에 맞게 on으로 시작하도록 수정해뒀습니다

## 📸 스크린샷 (권장)

![image](https://github.com/user-attachments/assets/638ff9aa-89a5-49b7-9793-f4fcff5a22d5)

## 🙏 리뷰 참고 (선택 사항)

> 개발 과정에서 다른 분들의 의견이 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요.

## 📄 기타 (선택 사항)

> 그 외 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
