### PR TITLE
[Feat] 전략상세 조건부렌더링 및 분석차트 api 

### DIFF
--- a/app/(dashboard)/_ui/details-side-item/index.tsx
+++ b/app/(dashboard)/_ui/details-side-item/index.tsx
@@ -22,9 +22,10 @@ export interface InformationModel {
 interface Props {
   information: InformationModel | InformationModel[]
   profileImage?: string
+  isMyStrategy?: boolean
 }
 
-const DetailsSideItem = ({ information, profileImage }: Props) => {
+const DetailsSideItem = ({ information, profileImage, isMyStrategy = true }: Props) => {
   const isArray = Array.isArray(information)
   return (
     <>
@@ -40,7 +41,12 @@ const DetailsSideItem = ({ information, profileImage }: Props) => {
           ))}
         </div>
       ) : (
-        <SideItem title={information.title} data={information.data} profileImage={profileImage} />
+        <SideItem
+          title={information.title}
+          data={information.data}
+          profileImage={profileImage}
+          isMyStrategy={isMyStrategy}
+        />
       )}
     </>
   )

--- a/app/(dashboard)/_ui/details-side-item/side-item.tsx
+++ b/app/(dashboard)/_ui/details-side-item/side-item.tsx
@@ -13,9 +13,10 @@ interface Props {
   title: Omit<TitleType, '트레이더' | '최소 투자 금액' | '투자 원금'>
   data: number | string
   profileImage?: string
+  isMyStrategy?: boolean
 }
 
-const SideItem = ({ title, data, profileImage }: Props) => {
+const SideItem = ({ title, data, profileImage, isMyStrategy = false }: Props) => {
   return (
     <div className={cx('side-item')}>
       <div className={cx('title')}>{title}</div>
@@ -26,9 +27,11 @@ const SideItem = ({ title, data, profileImage }: Props) => {
               <Avatar src={profileImage} />
               <p>{data}</p>
             </div>
-            <LinkButton href={PATH.MY_QUESTIONS} size="small" style={{ height: '30px' }}>
-              문의하기
-            </LinkButton>
+            {!isMyStrategy && (
+              <LinkButton href={PATH.MY_QUESTIONS} size="small" style={{ height: '30px' }}>
+                문의하기
+              </LinkButton>
+            )}
           </>
         ) : (
           <p>{data}</p>

--- a/app/(dashboard)/_ui/strategies-item/styles.module.scss
+++ b/app/(dashboard)/_ui/strategies-item/styles.module.scss
@@ -47,12 +47,10 @@
     display: flex;
     align-items: center;
     height: 20px;
+    gap: 6px;
     p {
       @include typo-c1;
       padding-top: 10px;
-      &:first-child {
-        margin-right: 6px;
-      }
     }
   }
 }

--- a/app/(dashboard)/my/strategies/manage/[strategyId]/page.tsx
+++ b/app/(dashboard)/my/strategies/manage/[strategyId]/page.tsx
@@ -48,7 +48,7 @@ const StrategyManagePage = ({ params }: { params: { strategyId: number } }) => {
         {detailsInformationData && (
           <DetailsInformation information={detailsInformationData} type="my" />
         )}
-        <AnalysisContainer type="my" />
+        <AnalysisContainer type="my" strategyId={params.strategyId} />
         <SideContainer hasButton={true}>
           <SubscriberItem subscribers={99} />
           {hasDetailsSideData?.[0] &&

--- a/app/(dashboard)/strategies/[strategyId]/_api/get-analysis-chart.ts
+++ b/app/(dashboard)/strategies/[strategyId]/_api/get-analysis-chart.ts
@@ -1,0 +1,20 @@
+import axios from 'axios'
+
+import { OptionsType } from '../_ui/analysis-container'
+
+const getAnalysisChart = async (
+  strategyId: number,
+  firstOption: OptionsType,
+  secondOption: OptionsType
+) => {
+  try {
+    const response = await axios.get(
+      `/api/strategies/${strategyId}/analysis?option1=${firstOption}&option2=${secondOption}`
+    )
+    return response.data.result
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+export default getAnalysisChart

--- a/app/(dashboard)/strategies/[strategyId]/_api/get-analysis-chart.ts
+++ b/app/(dashboard)/strategies/[strategyId]/_api/get-analysis-chart.ts
@@ -1,11 +1,11 @@
 import axios from 'axios'
 
-import { OptionsType } from '../_ui/analysis-container'
+import { AnalysisChartOptionsType } from '../_ui/analysis-container'
 
 const getAnalysisChart = async (
   strategyId: number,
-  firstOption: OptionsType,
-  secondOption: OptionsType
+  firstOption: AnalysisChartOptionsType,
+  secondOption: AnalysisChartOptionsType
 ) => {
   try {
     const response = await axios.get(

--- a/app/(dashboard)/strategies/[strategyId]/_hooks/query/use-get-analysis-chart.ts
+++ b/app/(dashboard)/strategies/[strategyId]/_hooks/query/use-get-analysis-chart.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query'
+
+import getAnalysisChart from '../../_api/get-analysis-chart'
+import { OptionsType } from '../../_ui/analysis-container'
+
+interface Props {
+  strategyId: number
+  firstOption: OptionsType
+  secondOption: OptionsType
+}
+
+const useGetAnalysisChart = ({ strategyId, firstOption, secondOption }: Props) => {
+  return useQuery({
+    queryKey: ['analysisChart', strategyId, firstOption, secondOption],
+    queryFn: () => getAnalysisChart(strategyId, firstOption, secondOption),
+  })
+}
+
+export default useGetAnalysisChart

--- a/app/(dashboard)/strategies/[strategyId]/_hooks/query/use-get-analysis-chart.ts
+++ b/app/(dashboard)/strategies/[strategyId]/_hooks/query/use-get-analysis-chart.ts
@@ -1,12 +1,12 @@
 import { useQuery } from '@tanstack/react-query'
 
 import getAnalysisChart from '../../_api/get-analysis-chart'
-import { OptionsType } from '../../_ui/analysis-container'
+import { AnalysisChartOptionsType } from '../../_ui/analysis-container'
 
 interface Props {
   strategyId: number
-  firstOption: OptionsType
-  secondOption: OptionsType
+  firstOption: AnalysisChartOptionsType
+  secondOption: AnalysisChartOptionsType
 }
 
 const useGetAnalysisChart = ({ strategyId, firstOption, secondOption }: Props) => {

--- a/app/(dashboard)/strategies/[strategyId]/_ui/analysis-container/analysis-chart.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/analysis-container/analysis-chart.tsx
@@ -32,7 +32,7 @@ const AnalysisChart = ({ analysisChartData: data }: Props) => {
     const key = Object.keys(data.data)[sequence] as YAxisType | undefined
     return key ? YAXIS_OPTIONS[key] : ''
   }
-
+  if (!data) return null
   const chartOptions: Highcharts.Options = {
     chart: {
       type: 'areaspline',

--- a/app/(dashboard)/strategies/[strategyId]/_ui/analysis-container/analysis-chart.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/analysis-container/analysis-chart.tsx
@@ -54,7 +54,7 @@ const AnalysisChart = ({ analysisChartData: data }: Props) => {
       verticalAlign: 'top',
       layout: 'vertical',
       x: 10,
-      y: 10,
+      y: 0,
       itemStyle: {
         color: '#4D4D4D',
         fontSize: '12px',

--- a/app/(dashboard)/strategies/[strategyId]/_ui/analysis-container/index.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/analysis-container/index.tsx
@@ -6,24 +6,25 @@ import classNames from 'classnames/bind'
 
 import Select from '@/shared/ui/select'
 
+import useGetAnalysisChart from '../../_hooks/query/use-get-analysis-chart'
 import AnalysisChart from './analysis-chart'
-import { analysisChartData } from './example'
 import styles from './styles.module.scss'
 import TabsWithTable from './tabs-width-table'
 import { YAXIS_OPTIONS } from './yaxis-options'
 
 const cx = classNames.bind(styles)
 
-type OptionsType = (typeof YAXIS_OPTIONS)[keyof typeof YAXIS_OPTIONS]
+export type OptionsType = keyof typeof YAXIS_OPTIONS
 
 interface Props {
+  strategyId: number
   type?: 'default' | 'my'
 }
 
-const AnalysisContainer = ({ type = 'default' }: Props) => {
-  const [firstValue, setFirstValue] = useState<OptionsType>('잔고')
-  const [secondValue, setSecondValue] = useState<OptionsType>('잔고')
-
+const AnalysisContainer = ({ strategyId, type = 'default' }: Props) => {
+  const [firstOption, setFirstOption] = useState<OptionsType>('PRINCIPAL')
+  const [secondOption, setSecondOption] = useState<OptionsType>('CUMULATIVE_PROFIT_LOSS')
+  const { data: chartData } = useGetAnalysisChart({ strategyId, firstOption, secondOption })
   const optionsToArray = Object.entries(YAXIS_OPTIONS)
   const options: { value: string; label: string }[] = []
 
@@ -40,21 +41,21 @@ const AnalysisContainer = ({ type = 'default' }: Props) => {
             <Select
               size="large"
               options={options}
-              value={firstValue}
-              onChange={(newValue) => setFirstValue(newValue as OptionsType)}
+              value={firstOption}
+              onChange={(newValue) => setFirstOption(newValue as OptionsType)}
             />
             <Select
               size="large"
               options={options}
-              value={secondValue}
-              onChange={(newValue) => setSecondValue(newValue as OptionsType)}
+              value={secondOption}
+              onChange={(newValue) => setSecondOption(newValue as OptionsType)}
             />
           </div>
         )}
       </div>
       {type === 'default' && (
         <div className={cx('chart-wrapper')}>
-          <AnalysisChart analysisChartData={analysisChartData} />
+          <AnalysisChart analysisChartData={chartData} />
         </div>
       )}
       <TabsWithTable isEditable={type === 'my' ? true : false} />

--- a/app/(dashboard)/strategies/[strategyId]/_ui/analysis-container/index.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/analysis-container/index.tsx
@@ -14,7 +14,7 @@ import { YAXIS_OPTIONS } from './yaxis-options'
 
 const cx = classNames.bind(styles)
 
-export type OptionsType = keyof typeof YAXIS_OPTIONS
+export type AnalysisChartOptionsType = keyof typeof YAXIS_OPTIONS
 
 interface Props {
   strategyId: number
@@ -22,8 +22,9 @@ interface Props {
 }
 
 const AnalysisContainer = ({ strategyId, type = 'default' }: Props) => {
-  const [firstOption, setFirstOption] = useState<OptionsType>('PRINCIPAL')
-  const [secondOption, setSecondOption] = useState<OptionsType>('CUMULATIVE_PROFIT_LOSS')
+  const [firstOption, setFirstOption] = useState<AnalysisChartOptionsType>('PRINCIPAL')
+  const [secondOption, setSecondOption] =
+    useState<AnalysisChartOptionsType>('CUMULATIVE_PROFIT_LOSS')
   const { data: chartData } = useGetAnalysisChart({ strategyId, firstOption, secondOption })
   const optionsToArray = Object.entries(YAXIS_OPTIONS)
   const options: { value: string; label: string }[] = []
@@ -42,13 +43,13 @@ const AnalysisContainer = ({ strategyId, type = 'default' }: Props) => {
               size="large"
               options={options}
               value={firstOption}
-              onChange={(newValue) => setFirstOption(newValue as OptionsType)}
+              onChange={(newValue) => setFirstOption(newValue as AnalysisChartOptionsType)}
             />
             <Select
               size="large"
               options={options}
               value={secondOption}
-              onChange={(newValue) => setSecondOption(newValue as OptionsType)}
+              onChange={(newValue) => setSecondOption(newValue as AnalysisChartOptionsType)}
             />
           </div>
         )}

--- a/app/(dashboard)/strategies/[strategyId]/_ui/review-container/review-item.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/review-container/review-item.tsx
@@ -14,6 +14,7 @@ interface Props {
   createdAt: string
   starRating: number
   isReviewer: boolean
+  isAdmin: boolean
 }
 
 const ReviewItem = ({
@@ -23,6 +24,7 @@ const ReviewItem = ({
   starRating,
   content,
   isReviewer,
+  isAdmin,
 }: Props) => {
   const editedCreatedAt = createdAt.slice(0, -3)
 
@@ -36,12 +38,15 @@ const ReviewItem = ({
           <span>{editedCreatedAt}</span>
           <StarRating starRating={starRating} />
         </div>
-        {isReviewer && (
-          <div className={cx('button-wrapper')}>
-            <button>수정</button>
-            <button>삭제</button>
-          </div>
-        )}
+        <div className={cx('button-wrapper')}>
+          {isReviewer && (
+            <>
+              <button>수정</button>
+              <button>삭제</button>
+            </>
+          )}
+          {!isReviewer && isAdmin && <button>삭제</button>}
+        </div>
       </div>
       <div className={cx('content')}>{content}</div>
     </li>

--- a/app/(dashboard)/strategies/[strategyId]/_ui/review-container/review-list.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/review-container/review-list.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames/bind'
 
+import { useAuthStore } from '@/shared/stores/use-auth-store'
 import Pagination from '@/shared/ui/pagination'
 
 import ReviewItem from './review-item'
@@ -27,6 +28,7 @@ interface Props {
 
 const ReviewList = ({ reviews, totalReview, currentPage, setCurrentPage }: Props) => {
   const handlePageChange = (page: number) => setCurrentPage(page)
+  const user = useAuthStore((state) => state.user)
 
   return (
     <>
@@ -39,7 +41,8 @@ const ReviewList = ({ reviews, totalReview, currentPage, setCurrentPage }: Props
             createdAt={review.createdAt}
             starRating={review.starRating}
             content={review.content}
-            isReviewer={'' === review.nickname}
+            isReviewer={user?.nickname === review.nickname}
+            isAdmin={user?.role.includes('admin') ?? false}
           />
         ))}
       </ul>

--- a/app/(dashboard)/strategies/[strategyId]/_ui/subscriber-item/index.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/subscriber-item/index.tsx
@@ -17,14 +17,16 @@ interface Props {
 const SubscriberItem = ({ isMyStrategy = false, subscribers, onClick }: Props) => {
   return (
     <div className={cx('container')}>
-      <div className={cx('wrapper')}>
-        <div className={cx('contents')}>구독 | {subscribers}</div>
-        {!isMyStrategy && (
-          <Button size="small" variant="filled" onClick={onClick}>
-            구독하기
-          </Button>
-        )}
+      <div>
+        <span>구독 </span>
+        <span>| </span>
+        <span>{subscribers}</span>
       </div>
+      {!isMyStrategy && (
+        <Button size="small" variant="filled" onClick={onClick}>
+          구독하기
+        </Button>
+      )}
     </div>
   )
 }

--- a/app/(dashboard)/strategies/[strategyId]/_ui/subscriber-item/styles.module.scss
+++ b/app/(dashboard)/strategies/[strategyId]/_ui/subscriber-item/styles.module.scss
@@ -1,22 +1,16 @@
 .container {
   display: flex;
   align-items: center;
-  width: 276px;
+  justify-content: space-between;
   height: 83px;
-  padding: 22px 20px 22px 40px;
-  flex-shrink: 0;
+  padding: 0 30px;
   border-radius: 5px;
   background-color: $color-white;
   margin-bottom: 18px;
-}
-
-.wrapper {
-  display: flex;
-  align-items: center;
-  gap: 45px;
-}
-
-.contents {
-  color: $color-gray-800;
-  @include typo-b1;
+  span {
+    font-size: 18px;
+    font-weight: $text-semibold;
+    color: $color-gray-800;
+    margin-left: 4px;
+  }
 }

--- a/app/(dashboard)/strategies/[strategyId]/page.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useMSWStore } from '@/shared/stores/msw'
+import { useAuthStore } from '@/shared/stores/use-auth-store'
 import BackHeader from '@/shared/ui/header/back-header'
 import Title from '@/shared/ui/title'
 
@@ -16,12 +17,13 @@ export type InformationType = { title: TitleType; data: string | number } | Info
 
 const StrategyDetailPage = ({ params }: { params: { strategyId: number } }) => {
   const isReady = useMSWStore((state) => state.isReady)
+  const user = useAuthStore((state) => state.user)
   const { data } = useGetDetailsInformationData({
     isReady,
     strategyId: params.strategyId,
   })
 
-  const { detailsSideData, detailsInformationData } = data || {}
+  const { detailsSideData, detailsInformationData: information } = data || {}
 
   const hasDetailsSideData = detailsSideData?.map((data) => {
     if (!Array.isArray(data)) return data.data !== undefined
@@ -31,15 +33,24 @@ const StrategyDetailPage = ({ params }: { params: { strategyId: number } }) => {
     <div>
       <BackHeader label={'목록으로 돌아가기'} />
       <Title label={'전략 상세보기'} />
-      {detailsInformationData && <DetailsInformation information={detailsInformationData} />}
-      <AnalysisContainer />
+      {information && <DetailsInformation information={information} />}
+      <AnalysisContainer strategyId={params.strategyId} />
       <ReviewContainer strategyId={params.strategyId} />
       <SideContainer>
-        <SubscriberItem subscribers={99} />
-        {hasDetailsSideData?.[0] &&
+        {information && (
+          <SubscriberItem
+            isMyStrategy={user?.nickname === information.nickname}
+            subscribers={information?.subscriptionCount}
+          />
+        )}
+        {information &&
+          hasDetailsSideData?.[0] &&
           detailsSideData?.map((data, idx) => (
             <div key={`${data}_${idx}`}>
-              <DetailsSideItem information={data} />
+              <DetailsSideItem
+                information={data}
+                isMyStrategy={user?.nickname === information.nickname}
+              />
             </div>
           ))}
       </SideContainer>

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,22 +9,22 @@ const nextConfig = {
     @import "@/shared/styles/base/functions";
   `,
   },
-  // async rewrites() {
-  //   return [
-  //     {
-  //       source: '/api/users/reissue/refreshtoken',
-  //       destination: '/api/users/reissue/refreshtoken',
-  //     },
-  //     {
-  //       source: '/api/users/login',
-  //       destination: '/api/users/login',
-  //     },
-  //     {
-  //       source: '/api/:path*',
-  //       destination: 'http://15.164.90.102:8081/api/:path*',
-  //     },
-  //   ]
-  // },
+  async rewrites() {
+    return [
+      // {
+      //   source: '/api/users/reissue/refreshtoken',
+      //   destination: '/api/users/reissue/refreshtoken',
+      // },
+      // {
+      //   source: '/api/users/login',
+      //   destination: '/api/users/login',
+      // },
+      {
+        source: '/api/strategies/:path*',
+        destination: 'http://15.164.90.102:8081/api/strategies/:path*',
+      },
+    ]
+  },
   webpack: (config, { isServer }) => {
     if (isServer) {
       if (Array.isArray(config.resolve.alias)) {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

전략상세 조건부렌더링 및 분석차트 api 

## 🔧 변경 사항

- 전략상세 유저타입에 따라 조건부렌더링 처리 (리뷰, 구독버튼, 문의하기버튼)
- 분석 차트 api 연결하여 렌더링
- 사이드바 쪽 구독 컴포넌트 디자인 수정

## 📸 스크린샷 (권장)

> 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 🙏 리뷰 참고 (선택 사항)

분석차트 예시데이터 스토리북에서 사용 중이라 지우지않았습니다.

## 📄 기타 (선택 사항)

> 그 외 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
