### PR TITLE
[Feat] 랜딩페이지 구독 상위 목록 및 sm 스코어 상위 목록 api 연결

### DIFF
--- a/app/(landing)/(home)/_api/top-strategies.ts
+++ b/app/(landing)/(home)/_api/top-strategies.ts
@@ -1,0 +1,11 @@
+import axios from 'axios'
+
+export const getTopRanking = async () => {
+  try {
+    const response = await axios.get('/api/main/top-ranking')
+    return response.data.result
+  } catch (err) {
+    console.error(err)
+    throw new Error('구독수 상위 전략 조회에 실패했습니다.')
+  }
+}

--- a/app/(landing)/(home)/_api/top-strategies.ts
+++ b/app/(landing)/(home)/_api/top-strategies.ts
@@ -9,3 +9,13 @@ export const getTopRanking = async () => {
     throw new Error('구독수 상위 전략 조회에 실패했습니다.')
   }
 }
+
+export const getTopRankingSmScore = async () => {
+  try {
+    const response = await axios.get('/api/main/top-ranking-smscore')
+    return response.data.result
+  } catch (err) {
+    console.error(err)
+    throw new Error('SM Score 상위 전략 조회에 실패했습니다.')
+  }
+}

--- a/app/(landing)/(home)/_hooks/query/use-get-top-ranking-smscore.ts
+++ b/app/(landing)/(home)/_hooks/query/use-get-top-ranking-smscore.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { StrategyCardModel } from '@/shared/types/strategy-data'
+
+import { getTopRankingSmScore } from '../../_api/top-strategies'
+
+const useGetTopRankingSmScore = () => {
+  return useQuery<StrategyCardModel[]>({
+    queryKey: ['topRankingSmScore'],
+    queryFn: getTopRankingSmScore,
+  })
+}
+
+export default useGetTopRankingSmScore

--- a/app/(landing)/(home)/_hooks/query/use-get-top-ranking.ts
+++ b/app/(landing)/(home)/_hooks/query/use-get-top-ranking.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { StrategyCardModel } from '@/shared/types/strategy-data'
+
+import { getTopRanking } from '../../_api/top-strategies'
+
+const useGetTopRanking = () => {
+  return useQuery<StrategyCardModel[]>({
+    queryKey: ['topRanking'],
+    queryFn: getTopRanking,
+  })
+}
+
+export default useGetTopRanking

--- a/app/(landing)/(home)/_ui/top-favorite-section/index.tsx
+++ b/app/(landing)/(home)/_ui/top-favorite-section/index.tsx
@@ -1,8 +1,11 @@
+'use client'
+
 import classNames from 'classnames/bind'
 
 import { PATH } from '@/shared/constants/path'
 import { LinkButton } from '@/shared/ui/link-button'
 
+import useGetTopRanking from '../../_hooks/query/use-get-top-ranking'
 import HomeSubtitle from '../home-subtitle'
 import TopFavoriteCard from '../top-strategy-card/top-favorite-card'
 import styles from './styles.module.scss'
@@ -10,44 +13,7 @@ import styles from './styles.module.scss'
 const cx = classNames.bind(styles)
 
 const TopFavoriteSection = () => {
-  const favoriteStrategies = [
-    {
-      strategyId: 3,
-      strategyName: '내 전략은 엄청나',
-      traderImgUrl: '',
-      nickname: '엄청난 트레이더',
-      profitRateChartData: [10, 9, 7, 12, 15, 13, 18, 34, 27, 40],
-      smScore: 75.0,
-      cumulativeProfitRate: 60.63,
-      subscriptionCount: 1234,
-      averageRating: 5.0,
-      totalReviews: 32,
-    },
-    {
-      strategyId: 1,
-      strategyName: '내 전략은 꽤나 대단해',
-      traderImgUrl: '',
-      nickname: '대단한 트레이더',
-      profitRateChartData: [15.0, 32.0, 98.0, 29.0, 1.0, 59.0],
-      smScore: 80.0,
-      cumulativeProfitRate: 50.0,
-      subscriptionCount: 759,
-      averageRating: 4.9,
-      totalReviews: 62,
-    },
-    {
-      strategyId: 2,
-      strategyName: '나 유명한데 한번 믿어봐',
-      traderImgUrl: '',
-      nickname: '엄청난 트레이더',
-      profitRateChartData: [10, 9, 7, 12, 15, 13, 18, 34, 27, 40],
-      smScore: 70.0,
-      cumulativeProfitRate: 57.0,
-      subscriptionCount: 777,
-      averageRating: 5.0,
-      totalReviews: 20,
-    },
-  ]
+  const { data: favoriteStrategies } = useGetTopRanking()
 
   return (
     <section className={cx('section-container')}>
@@ -57,20 +23,21 @@ const TopFavoriteSection = () => {
       </HomeSubtitle>
 
       <ul className={cx('strategy-wrapper')}>
-        {favoriteStrategies.map((strategy, idx) => (
-          <li key={strategy.strategyId}>
-            <TopFavoriteCard
-              ranking={idx + 1}
-              nickname={strategy.nickname}
-              title={strategy.strategyName}
-              chartData={strategy.profitRateChartData}
-              percentageChange={strategy.cumulativeProfitRate}
-              subscriptionCount={strategy.subscriptionCount}
-              averageRating={strategy.averageRating}
-              reviewCount={strategy.totalReviews}
-            />
-          </li>
-        ))}
+        {favoriteStrategies &&
+          favoriteStrategies.map((strategy, idx) => (
+            <li key={strategy.strategyId}>
+              <TopFavoriteCard
+                ranking={idx + 1}
+                nickname={strategy.nickname}
+                title={strategy.strategyName}
+                chartData={strategy.profitRateChartData}
+                percentageChange={strategy.cumulativeProfitRate}
+                subscriptionCount={strategy.subscriptionCount}
+                averageRating={strategy.averageRating}
+                reviewCount={strategy.totalReviews}
+              />
+            </li>
+          ))}
       </ul>
 
       <LinkButton href={PATH.STRATEGIES} variant="filled">

--- a/app/(landing)/(home)/_ui/top-sm-score-section/index.tsx
+++ b/app/(landing)/(home)/_ui/top-sm-score-section/index.tsx
@@ -1,5 +1,8 @@
+'use client'
+
 import classNames from 'classnames/bind'
 
+import useGetTopRankingSmScore from '../../_hooks/query/use-get-top-ranking-smscore'
 import HomeSubtitle from '../home-subtitle'
 import TopSmScoreCard from '../top-strategy-card/top-sm-score-card'
 import styles from './styles.module.scss'
@@ -7,87 +10,27 @@ import styles from './styles.module.scss'
 const cx = classNames.bind(styles)
 
 const TopSmScoreSection = () => {
-  const topSmScoreStrategies = [
-    {
-      strategyId: 3,
-      strategyName: '내 전략은 엄청나',
-      traderImgUrl: '',
-      nickname: '엄청난 트레이더',
-      profitRateChartData: [10, 9, 7, 12, 15, 13, 18, 34, 27, 40],
-      smScore: 95.01,
-      cumulativeProfitRate: 60.6,
-      subscriptionCount: 1234,
-      averageRating: 5.0,
-      totalReviews: 32,
-    },
-    {
-      strategyId: 1,
-      strategyName: '내 전략은 꽤나 대단해',
-      traderImgUrl: '',
-      nickname: '대단한 트레이더',
-      profitRateChartData: [15.0, 32.0, 98.0, 29.0, 1.0, 59.0],
-      smScore: 80.02,
-      cumulativeProfitRate: 50.0,
-      subscriptionCount: 759,
-      averageRating: 4.9,
-      totalReviews: 62,
-    },
-    {
-      strategyId: 2,
-      strategyName: '나 유명한데 한번 믿어봐',
-      traderImgUrl: '',
-      nickname: '엄청난 트레이더',
-      profitRateChartData: [10, 9, 7, 12, 15, 13, 18, 34, 27, 40],
-      smScore: 70.01,
-      cumulativeProfitRate: 57.0,
-      subscriptionCount: 777,
-      averageRating: 5.0,
-      totalReviews: 20,
-    },
-    {
-      strategyId: 4,
-      strategyName: '나 유명한데 한번 믿어봐',
-      traderImgUrl: '',
-      nickname: '엄청난 트레이더',
-      profitRateChartData: [10, 9, 7, 12, 15, 13, 18, 34, 27, 40],
-      smScore: 70.0,
-      cumulativeProfitRate: 57.0,
-      subscriptionCount: 777,
-      averageRating: 5.0,
-      totalReviews: 20,
-    },
-    {
-      strategyId: 5,
-      strategyName: '나 유명한데 한번 믿어봐',
-      traderImgUrl: '',
-      nickname: '엄청난 트레이더',
-      profitRateChartData: [10, 9, 7, 12, 15, 13, 18, 34, 27, 40],
-      smScore: 70.0,
-      cumulativeProfitRate: 57.0,
-      subscriptionCount: 777,
-      averageRating: 5.0,
-      totalReviews: 20,
-    },
-  ]
+  const { data: topSmScoreStrategies } = useGetTopRankingSmScore()
 
   return (
     <section className={cx('section-container')}>
       <HomeSubtitle>높은 SM 스코어별로 전략을 확인해보세요!</HomeSubtitle>
 
       <ul className={cx('strategy-wrapper')}>
-        {topSmScoreStrategies.map((strategy, idx) => (
-          <li key={strategy.strategyId}>
-            <TopSmScoreCard
-              size={idx > 0 ? 'small' : 'large'}
-              ranking={idx + 1}
-              nickname={strategy.nickname}
-              title={strategy.strategyName}
-              chartData={strategy.profitRateChartData}
-              percentageChange={strategy.cumulativeProfitRate}
-              score={strategy.smScore}
-            />
-          </li>
-        ))}
+        {topSmScoreStrategies &&
+          topSmScoreStrategies.map((strategy, idx) => (
+            <li key={strategy.strategyId}>
+              <TopSmScoreCard
+                size={idx > 0 ? 'small' : 'large'}
+                ranking={idx + 1}
+                nickname={strategy.nickname}
+                title={strategy.strategyName}
+                chartData={strategy.profitRateChartData}
+                percentageChange={strategy.cumulativeProfitRate}
+                score={strategy.smScore}
+              />
+            </li>
+          ))}
       </ul>
     </section>
   )

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -23,6 +23,10 @@ const nextConfig = {
         source: '/api/strategies/:path*',
         destination: 'http://15.164.90.102:8081/api/strategies/:path*',
       },
+      {
+        source: '/api/main/:path*',
+        destination: 'http://15.164.90.102:8081/api/main/:path*',
+      },
     ]
   },
   webpack: (config, { isServer }) => {

--- a/shared/types/strategy-data.ts
+++ b/shared/types/strategy-data.ts
@@ -62,3 +62,16 @@ export interface StrategyDetailsInformationModel extends BaseStrategyModel {
   finalProfitLossDate: string
   createdAt: string
 }
+
+export interface StrategyCardModel {
+  strategyId: number
+  strategyName: string
+  TraderImgUrl: string
+  nickname: string
+  profitRateChartData: number[]
+  smScore: number
+  cumulativeProfitRate: number
+  subscriptionCount: number
+  averageRating: number
+  totalReviews: number
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

구독 상위 목록 및 sm 스코어 상위 목록 api 연결했습니다!
나머지는 아직 안나옴...

## 🔧 변경 사항

> 주요 변경 사항을 요약해 주세요. ex) validate 로직 수정, package.json 수정, 파일 수정/삭제 등

## 📸 스크린샷 (권장)

<img width="992" alt="image" src="https://github.com/user-attachments/assets/672f3449-72e6-4597-bf1e-32009958abaf">

## 🙏 리뷰 참고 (선택 사항)

> 개발 과정에서 다른 분들의 의견이 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요.

## 📄 기타 (선택 사항)

> 그 외 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
