### PR TITLE
[Feat] suspense를 씌워주는 HOC 추가

### DIFF
--- a/shared/utils/with-suspense.tsx
+++ b/shared/utils/with-suspense.tsx
@@ -1,0 +1,15 @@
+import { ComponentType, ReactNode, Suspense } from 'react'
+
+function withSuspense<P>(Component: ComponentType<P>, fallback: ReactNode = <div>Loading...</div>) {
+  const WrappedComponent = (props: P & JSX.IntrinsicAttributes) => (
+    <Suspense fallback={fallback}>
+      <Component {...props} />
+    </Suspense>
+  )
+
+  WrappedComponent.displayName = `withSuspense(${Component.displayName || Component.name || 'Component'})`
+
+  return WrappedComponent
+}
+
+export default withSuspense


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

> 제곧내
상위요소에서 Suspense로 감싸기보다 각 컴포넌트 내부에서 로직을 처리하는 것이 더 응집도가 높고, 추후 보수에서도 효과적이라고 생각해서  도입하게 됐습니다.

## 사용법 
```
// 컴포넌트.tsx
export default withSuspense(컴포넌트 이름, fallback UI)
```