### PR TITLE
[Refactor] tab 컴포넌트가 content를 선택적으로 받도록 수정 및 onChange type 개선

### DIFF
--- a/shared/ui/tabs/index.tsx
+++ b/shared/ui/tabs/index.tsx
@@ -10,29 +10,31 @@ export interface TabItemModel {
   id: string
   label: string
   icon?: React.FC<React.SVGProps<SVGSVGElement>>
-  content: React.ReactElement
+  content?: React.ReactElement
 }
 
-interface Props {
+interface Props<T extends string> {
   tabs: TabItemModel[]
-  activeTab: string
-  onTabChange: (id: string) => void
+  activeTab: T
+  onTabChange: (id: T) => void
 }
 
-const Tabs = ({ tabs, activeTab, onTabChange }: Props) => {
+const Tabs = <T extends string>({ tabs, activeTab, onTabChange }: Props<T>) => {
+  const activeTabContent = tabs.find((tab) => tab.id === activeTab)?.content
+
   return (
     <>
       <ul className={cx('tab-list')}>
         {tabs.map(({ id, label, icon: Icon }) => (
           <li key={id}>
-            <TabButton isActive={id === activeTab} onClick={() => onTabChange(id)}>
+            <TabButton isActive={id === activeTab} onClick={() => onTabChange(id as T)}>
               {Icon && <Icon className={cx('icon')} />}
               {label}
             </TabButton>
           </li>
         ))}
       </ul>
-      <div>{tabs.find((tab) => tab.id === activeTab)?.content}</div>
+      {activeTabContent && <div>{activeTabContent}</div>}
     </>
   )
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

1. 기존에는 tabs 컴포넌트가 tabs 속성 내에 content를 받아 랜더링하는 역할도 수행했습니다. 이 때, 동일한 컴포넌트에 대해 데이터만 다르게 전달하는 경우 불필요하게 구조가 복잡해지는 문제가 있었습니다.
예를 들어, 컨테이너 컴포넌트에서 유저 전체 정보를 받고, 유저의 role을 기준으로 데이터를 filter 후 tab에 맞춰 랜더링할 때,
content로 컴포넌트를 넘기는 경우 각 경우에 대해 content를 넘겨야합니다. 반면 컨테이너 컴포넌트에서 state로 관리한다면 컴포넌트는 하나로 해결 가능합니다. 즉 다음과 같습니다.
```tsx
const [user, set...] = useState( )
const [tab, set...] = useState( )

// 기존
     <Tabs
          tabs={tabs.map((tab) => ({
            id: tab,
            label: tab,
            content: <UserList data={ tab를 통해 구한 각 텝에 필요한 데이터 } 
          }))}
          activeTab={tabs[0]}
          onTabChange={(id) => alert(id)}
      />

// 변경 후
     <Tabs
          tabs={tabs.map((tab) => ({
            id: tab,
            label: tab,
          }))}
          activeTab={tabs[0]}
          onTabChange={(id) => alert(id)}
      />
     <UserList data={ state를 통해 구한 각 텝에 필요한 데이터 }
```

2. 사용하는 컴포넌트에서 onChange로 콜백 함수를 넘길 때, 인자로 리터럴 타입이 넘어가면 setState에 as를 통해 타입을 지정해줘야하는 문제가 있었습니다.
```tsx
     type CategoryModel : '주식' | '펀드'
     const [category, set....]  = useState<CategoryModel>('주식')
     <Tabs
          .....
          onTabChange={(category) => setState(category as CategoryModel )}  // here
      />
```
setState는 CategoryModel을 받을 것을 예상하지만, onTabChange에서 인자로 string을 받도록 설정되어있어서 생기는 문제였습니다. 따라서 인자로 string을 받되, 인자가 리터럴 타입인 경우에는 리터럴 타입으로 캐스팅 되도록 설정했습니다.
