### PR TITLE
[Utils] API response base interface 추가

### DIFF
--- a/shared/types/response.ts
+++ b/shared/types/response.ts
@@ -1,0 +1,5 @@
+export interface APIResponseBaseModel<T extends boolean> {
+  isSuccess: T
+  message: string
+  code: T extends false ? number : never
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

API response에 항상 다음과 같은 값이 있어서 기저 타입을 만들어서 추가했습니다.
```ts
export interface APIResponseBaseModel<T extends boolean> {
  isSuccess: T
  message: string
  code: T extends false ? number : never
}
```
간단히 설명하자면, isSuccess는 boolean타입이고,  isSuccess가 false인 경우에만 code속성이 존재하는 타입입니다.

## 예시 코드

```ts
export interface PresignedUrlResponseModel extends APIResponseBaseModel<boolean> {
// APIResponseBaseModel에 없는 속성에 대해서만 작성
  result: {
    presignedUrl: string
  }
```