### PR TITLE
[Feat] 전략 통계 "%", "일" 수치 표시 추가

### DIFF
--- a/shared/ui/table/statistics/constant.ts
+++ b/shared/ui/table/statistics/constant.ts
@@ -34,3 +34,24 @@ export const inKoreanData = {
   ddMddInfo: 'DD&MDD 정보',
   tradingInfo: '거래 관련 정보',
 } as const
+
+export const STATISTICS_PERCENT = [
+  '누적 수익률',
+  '최대 누적 수익률',
+  '평균 손익률',
+  '최대 일 수익률',
+  '최대 일 손실률',
+  '현재 자본 인하율',
+  '최대 자본 인하율',
+  '승률',
+]
+
+export const STATISTICS_DATE = [
+  '고점 갱신 후 경과일',
+  '총 거래 일수',
+  '총 이익 일수',
+  '총 손실 일수',
+  '현재 연속 손익 일수',
+  '최대 연속 이익 일수',
+  '최대 연속 손실 일수',
+]

--- a/shared/ui/table/statistics/index.tsx
+++ b/shared/ui/table/statistics/index.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames/bind'
 
 import { formatNumber } from '@/shared/utils/format'
 
-import { inKoreanData } from './in-korean'
+import { STATISTICS_DATE, STATISTICS_PERCENT, inKoreanData } from './constant'
 import styles from './styles.module.scss'
 
 const cx = classNames.bind(styles)
@@ -50,11 +50,19 @@ const StatisticsTable = ({ title, statisticsData }: Props) => {
           {groupedData.map((row, idx) => (
             <tr key={idx}>
               <td>{row[0]}</td>
-              <td>{formatNumber(row[1])}</td>
+              <td>
+                {formatNumber(row[1])}
+                {STATISTICS_PERCENT.includes(row[0] as string) && '%'}
+                {STATISTICS_DATE.includes(row[0] as string) && '일'}
+              </td>
               {row[2] && (
                 <>
                   <td>{row[2]}</td>
-                  <td>{formatNumber(row[3])}</td>
+                  <td>
+                    {formatNumber(row[3])}
+                    {STATISTICS_PERCENT.includes(row[2] as string) && '%'}
+                    {STATISTICS_DATE.includes(row[2] as string) && '일'}
+                  </td>
                 </>
               )}
             </tr>


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

전략 통계 %,일 수치 표시 추가

## 🔧 변경 사항

전략 통계 %,일 수치 표시 추가

## 📸 스크린샷 (권장)

> 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 🙏 리뷰 참고 (선택 사항)

> 개발 과정에서 다른 분들의 의견이 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요.

## 📄 기타 (선택 사항)

> 그 외 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
