### PR TITLE
[Feat] 나의 전략일때 구독 할 수 없는 경고 모달 적용

### DIFF
--- a/app/(dashboard)/_ui/strategies-item/index.tsx
+++ b/app/(dashboard)/_ui/strategies-item/index.tsx
@@ -49,7 +49,11 @@ const StrategiesItem = ({ strategiesData: data, type = 'default' }: Props) => {
       </div>
       {type === 'default' && (
         <div className={cx('subscribe')}>
-          <Subscribe subscriptionStatus={data.isSubscribed} strategyId={data.strategyId} />
+          <Subscribe
+            subscriptionStatus={data.isSubscribed}
+            strategyId={data.strategyId}
+            traderName={data.nickname}
+          />
         </div>
       )}
       {type === 'my' && (

--- a/shared/hooks/custom/use-modal.ts
+++ b/shared/hooks/custom/use-modal.ts
@@ -6,7 +6,12 @@ const useModal = () => {
   const [isModalOpen, setIsModalOpen] = useState(false)
 
   const openModal = () => setIsModalOpen(true)
-  const closeModal = () => setIsModalOpen(false)
+  const closeModal = (e?: React.MouseEvent) => {
+    if (e) {
+      e.preventDefault()
+    }
+    setIsModalOpen(false)
+  }
 
   return {
     isModalOpen,

--- a/shared/ui/modal/subscribe-warning-modal.tsx
+++ b/shared/ui/modal/subscribe-warning-modal.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+import { ModalAlertIcon } from '@/public/icons'
+import classNames from 'classnames/bind'
+
+import Modal from '.'
+import { Button } from '../button'
+import styles from './styles.module.scss'
+
+const cx = classNames.bind(styles)
+
+interface Props {
+  isModalOpen: boolean
+  onCloseModal: () => void
+}
+
+const SubscribeWarningModal = ({ isModalOpen, onCloseModal }: Props) => {
+  return (
+    <Modal isOpen={isModalOpen} icon={ModalAlertIcon}>
+      <span className={cx('message')}>나의 전략은 구독 할 수 없습니다.</span>
+      <Button onClick={onCloseModal}>확인</Button>
+    </Modal>
+  )
+}
+
+export default SubscribeWarningModal


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

나의 전략일때 구독 할 수 없는 경고 모달 적용

## 🔧 변경 사항

- 나의 전략일때 구독 할 수 없는 경고 모달 적용
- 커스텀 훅 closeModal 핸들러에 이벤트 전파되서 preventDefault 적용 (페이지 이동됨..)

## 📸 스크린샷 (권장)

<img width="459" alt="image" src="https://github.com/user-attachments/assets/d92af472-a828-401c-91b5-fe2a3a952e04">

## 🙏 리뷰 참고 (선택 사항)

> 개발 과정에서 다른 분들의 의견이 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요.

## 📄 기타 (선택 사항)

> 그 외 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
