### PR TITLE
[Feat] 전략목록 스켈레톤 ui 추가 및 적용 

### DIFF
--- a/app/(dashboard)/_ui/strategies-item/skeleton/index.tsx
+++ b/app/(dashboard)/_ui/strategies-item/skeleton/index.tsx
@@ -1,0 +1,29 @@
+import classNames from 'classnames/bind'
+
+import styles from './styles.module.scss'
+
+const cx = classNames.bind(styles)
+
+const StrategiesItemSkeleton = () => {
+  return (
+    <div className={cx('container')}>
+      <div className={cx('first')}>
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+      </div>
+      <div className={cx('second')}>
+        <div></div>
+      </div>
+      <div className={cx('last')}>
+        <div></div>
+      </div>
+      <div className={cx('last')}>
+        <div></div>
+      </div>
+    </div>
+  )
+}
+
+export default StrategiesItemSkeleton

--- a/app/(dashboard)/_ui/strategies-item/skeleton/styles.module.scss
+++ b/app/(dashboard)/_ui/strategies-item/skeleton/styles.module.scss
@@ -1,0 +1,48 @@
+.container {
+  @include skeleton;
+  margin-bottom: 24px;
+  display: grid;
+  grid-template-columns: 1.5fr 1.2fr 0.8fr repeat(2, 0.6fr) 0.4fr;
+  height: 158px;
+  width: 100%;
+  align-items: center;
+  grid-gap: 4px;
+  div {
+    width: 100%;
+  }
+  .first {
+    background-color: $color-gray-200;
+    justify-content: flex-start;
+    padding-left: 20px;
+    & * {
+      height: 18px;
+      margin-bottom: 10px;
+    }
+    :first-child {
+      width: 50px;
+    }
+    :nth-child(2) {
+      width: 250px;
+    }
+    :nth-child(3),
+    :nth-child(4) {
+      width: 120px;
+    }
+  }
+  .second {
+    background-color: $color-gray-200;
+    place-items: center center;
+    :first-child {
+      width: 140px;
+      height: 115px;
+    }
+  }
+  .last {
+    background-color: $color-gray-200;
+    place-items: center center;
+    :first-child {
+      width: 100px;
+      height: 18px;
+    }
+  }
+}

--- a/app/(dashboard)/strategies/_ui/search-bar/search-bar-skeleton/index.tsx
+++ b/app/(dashboard)/strategies/_ui/search-bar/search-bar-skeleton/index.tsx
@@ -1,0 +1,20 @@
+import classNames from 'classnames/bind'
+
+import styles from './styles.module.scss'
+
+const cx = classNames.bind(styles)
+
+const SearchBarSkeleton = () => {
+  return (
+    <>
+      <div className={cx('top')}></div>
+      <div className={cx('container')}>
+        {Array.from({ length: 7 }, (_, idx) => (
+          <div key={idx}></div>
+        ))}
+      </div>
+    </>
+  )
+}
+
+export default SearchBarSkeleton

--- a/app/(dashboard)/strategies/_ui/search-bar/search-bar-skeleton/styles.module.scss
+++ b/app/(dashboard)/strategies/_ui/search-bar/search-bar-skeleton/styles.module.scss
@@ -1,0 +1,20 @@
+.top {
+  @include skeleton;
+  width: 276px;
+  height: 66px;
+  margin-bottom: 10px;
+}
+.container {
+  @include skeleton;
+  width: 276px;
+  height: 520px;
+  padding: 15px;
+  * {
+    height: 40px;
+    width: 240px;
+    margin-bottom: 20px;
+  }
+  :first-child {
+    margin-top: 30px;
+  }
+}

--- a/app/(dashboard)/strategies/_ui/strategy-list/index.tsx
+++ b/app/(dashboard)/strategies/_ui/strategy-list/index.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect } from 'react'
 
-import ListHeader from '@/app/(dashboard)/_ui/list-header'
 import StrategiesItem from '@/app/(dashboard)/_ui/strategies-item'
 import classNames from 'classnames/bind'
 
@@ -38,7 +37,6 @@ const StrategyList = () => {
 
   return (
     <>
-      <ListHeader />
       {strategiesData?.map((strategy) => (
         <StrategiesItem key={strategy.strategyId} strategiesData={strategy} />
       ))}

--- a/app/(dashboard)/strategies/loading.tsx
+++ b/app/(dashboard)/strategies/loading.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+import StrategiesItemSkeleton from '../_ui/strategies-item/skeleton'
+
+const StrategiesLoading = () => {
+  return (
+    <div>
+      {Array.from({ length: 8 }, (_, idx) => (
+        <StrategiesItemSkeleton key={idx} />
+      ))}
+    </div>
+  )
+}
+
+export default StrategiesLoading

--- a/app/(dashboard)/strategies/page.module.scss
+++ b/app/(dashboard)/strategies/page.module.scss
@@ -2,7 +2,20 @@
   margin-top: 80px;
 }
 
-.search-bar {
-  width: 100%;
-  background-color: $color-orange-200;
+.strategy-layout {
+  display: flex;
+  position: relative;
+
+  .strategy {
+    width: calc(100% - $strategy-sidebar-width);
+    max-width: $max-width;
+    padding-right: 10px;
+  }
+}
+
+.skeleton-side-bar {
+  width: $strategy-sidebar-width;
+  position: absolute;
+  right: 0px;
+  top: 130px;
 }

--- a/app/(dashboard)/strategies/page.tsx
+++ b/app/(dashboard)/strategies/page.tsx
@@ -4,9 +4,12 @@ import classNames from 'classnames/bind'
 
 import Title from '@/shared/ui/title'
 
+import ListHeader from '../_ui/list-header'
 import SearchBarContainer from './_ui/search-bar'
+import SearchBarSkeleton from './_ui/search-bar/search-bar-skeleton'
 import SideContainer from './_ui/side-container'
 import StrategyList from './_ui/strategy-list'
+import StrategiesLoading from './loading'
 import styles from './page.module.scss'
 
 const cx = classNames.bind(styles)
@@ -15,11 +18,14 @@ const StrategiesPage = () => {
   return (
     <div className={cx('container')}>
       <Title label={'전략 랭킹 모음'} />
-      <Suspense fallback={<div>Loading...</div>}>
+      <ListHeader />
+      <Suspense fallback={<StrategiesLoading />}>
         <StrategyList />
       </Suspense>
       <SideContainer>
-        <SearchBarContainer />
+        <Suspense fallback={<SearchBarSkeleton />}>
+          <SearchBarContainer />
+        </Suspense>
       </SideContainer>
     </div>
   )


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

전략목록 스켈레톤 ui 추가 및 적용 

## 🔧 변경 사항

전략목록 스켈레톤 ui 추가 및 적용 
-strategy-list컴포넌트에서 list헤더 page.tsx로 옮기고 suspence로 로딩 시 스켈레톤ui보여짐.
-마이페이지에서도 strategy-list컴포넌트 쓰여서 해석님께 해당 내용 전달 완료!

## 📸 스크린샷 (권장)

<img width="1398" alt="스크린샷 2024-12-05 오후 6 48 41" src="https://github.com/user-attachments/assets/fdca8c4d-df52-46db-98f6-0b0ecad3eccd">

## 🙏 리뷰 참고 (선택 사항)

> 개발 과정에서 다른 분들의 의견이 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요.

## 📄 기타 (선택 사항)

> 그 외 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
