### PR TITLE
[Feat] 전략 상세 로딩 스켈레톤 추가 및 적용

### DIFF
--- a/app/(dashboard)/_ui/details-side-item/side-skeleton/index.tsx
+++ b/app/(dashboard)/_ui/details-side-item/side-skeleton/index.tsx
@@ -1,0 +1,16 @@
+import classNames from 'classnames/bind'
+
+import styles from './styles.module.scss'
+
+const cx = classNames.bind(styles)
+const SideSkeleton = () => {
+  return (
+    <div className={cx('container')}>
+      {Array.from({ length: 6 }, (_, idx) => (
+        <div key={idx}></div>
+      ))}
+    </div>
+  )
+}
+
+export default SideSkeleton

--- a/app/(dashboard)/_ui/details-side-item/side-skeleton/styles.module.scss
+++ b/app/(dashboard)/_ui/details-side-item/side-skeleton/styles.module.scss
@@ -1,0 +1,26 @@
+.container {
+  width: 100%;
+  div {
+    @include skeleton;
+    width: 100%;
+    margin-bottom: 20px;
+  }
+  :first-child {
+    height: 83px;
+  }
+  :nth-child(2) {
+    height: 122px;
+  }
+  :nth-child(3) {
+    height: 108px;
+  }
+  :nth-child(4) {
+    height: 108px;
+  }
+  :nth-child(5) {
+    height: 200px;
+  }
+  :nth-child(6) {
+    height: 200px;
+  }
+}

--- a/app/(dashboard)/strategies/[strategyId]/loading.module.scss
+++ b/app/(dashboard)/strategies/[strategyId]/loading.module.scss
@@ -1,0 +1,167 @@
+@mixin line-small {
+  width: 70px;
+  height: 17px;
+}
+
+@mixin line-medium {
+  width: 170px;
+  height: 25px;
+}
+
+@mixin line-large {
+  width: 236px;
+  height: 33px;
+}
+
+@mixin box-small {
+  width: 100px;
+  height: 33px;
+}
+
+@mixin box-medium {
+  width: 168px;
+  height: 33px;
+}
+
+@mixin box-large {
+  width: 417px;
+  height: 98px;
+}
+
+@mixin flex-column {
+  display: flex;
+  flex-direction: column;
+}
+
+.container {
+  margin-top: 20px;
+  .first-wrapper {
+    display: grid;
+    grid-template-columns: 0.5fr 1.5fr;
+    height: 132px;
+    gap: 10px;
+    margin-bottom: 20px;
+    .left {
+      @include skeleton;
+      @include flex-column;
+      padding: 10px;
+      * {
+        margin-bottom: 15px;
+      }
+      :first-child {
+        @include line-small;
+      }
+      :nth-child(2) {
+        @include line-medium;
+      }
+      :nth-child(3) {
+        @include line-large;
+      }
+    }
+    .right {
+      @include skeleton;
+      display: grid;
+      padding: 15px;
+      grid-template-columns: repeat(3, 1fr);
+      * {
+        margin-top: 10px;
+      }
+      :first-child {
+        @include skeleton;
+        @include flex-column;
+        :first-child {
+          @include box-small;
+        }
+        :nth-child(2) {
+          @include box-medium;
+        }
+      }
+      :nth-child(2) {
+        @include skeleton;
+        @include flex-column;
+        :first-child {
+          @include box-small;
+        }
+        :nth-child(2) {
+          @include box-medium;
+        }
+      }
+      :nth-child(3) {
+        @include skeleton;
+        @include flex-column;
+        :first-child {
+          @include box-small;
+        }
+        :nth-child(2) {
+          @include box-medium;
+        }
+      }
+    }
+  }
+  .second-wrapper {
+    height: 160px;
+    @include skeleton;
+    padding: 20px 20px 40px;
+    margin-bottom: 20px;
+    p {
+      margin-bottom: 10px;
+    }
+    div {
+      width: 100%;
+      height: 72px;
+    }
+  }
+  .third-wrapper {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 10px;
+    height: 108px;
+    margin-bottom: 20px;
+    div {
+      @include skeleton;
+      @include flex-column;
+      align-items: center;
+      padding: 10px;
+      div {
+        @include box-small;
+        margin: 5px 0;
+      }
+    }
+  }
+  .fourth-wrapper {
+    @include skeleton;
+    padding: 20px;
+    p {
+      margin-bottom: 10px;
+      @include typo-h4;
+      color: $color-gray-600;
+    }
+    .chart {
+      height: 367px;
+      margin-bottom: 30px;
+    }
+    .tab {
+      display: flex;
+      background-color: $color-gray-200;
+      margin-bottom: 30px;
+      div {
+        @include box-small;
+        margin-right: 10px;
+      }
+    }
+    .analysis {
+      background-color: $color-gray-200;
+      padding: 10px;
+      div {
+        display: flex;
+        justify-content: space-between;
+        @include skeleton;
+        div {
+          height: 131px;
+          width: 90%;
+          margin: 10px;
+        }
+      }
+    }
+  }
+}

--- a/app/(dashboard)/strategies/[strategyId]/loading.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/loading.tsx
@@ -1,0 +1,58 @@
+import classNames from 'classnames/bind'
+
+import styles from './loading.module.scss'
+
+const cx = classNames.bind(styles)
+
+const DetailsLoading = () => {
+  return (
+    <div className={cx('container')}>
+      <div className={cx('first-wrapper')}>
+        <div className={cx('left')}>
+          {Array.from({ length: 3 }, (_, idx) => (
+            <div key={idx}></div>
+          ))}
+        </div>
+        <div className={cx('right')}>
+          {Array.from({ length: 3 }, (_, idx) => (
+            <div key={idx}>
+              <div></div>
+              <div></div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className={cx('second-wrapper')}>
+        <p>전략 상세 소개</p>
+        <div></div>
+      </div>
+      <div className={cx('third-wrapper')}>
+        {Array.from({ length: 5 }, (_, idx) => (
+          <div key={idx}>
+            <div></div>
+            <div></div>
+          </div>
+        ))}
+      </div>
+      <div className={cx('fourth-wrapper')}>
+        <p>분석</p>
+        <div className={cx('chart')}></div>
+        <div className={cx('tab')}>
+          {Array.from({ length: 4 }, (_, idx) => (
+            <div key={idx}></div>
+          ))}
+        </div>
+        <div className={cx('analysis')}>
+          {Array.from({ length: 4 }, (_, idx) => (
+            <div key={idx}>
+              <div></div>
+              <div></div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default DetailsLoading

--- a/app/(dashboard)/strategies/[strategyId]/page.tsx
+++ b/app/(dashboard)/strategies/[strategyId]/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import AnalysisContainer from '@/app/(dashboard)/_ui/analysis-container'
-import SubscriberItem from '@/app/(dashboard)/_ui/subscriber-item'
+import React, { Suspense } from 'react'
+
+import dynamic from 'next/dynamic'
 
 import useModal from '@/shared/hooks/custom/use-modal'
 import { useAuthStore } from '@/shared/stores/use-auth-store'
@@ -9,12 +10,28 @@ import BackHeader from '@/shared/ui/header/back-header'
 import SubscribeCheckModal from '@/shared/ui/modal/subscribe-check-modal'
 import Title from '@/shared/ui/title'
 
-import DetailsInformation from '../../_ui/details-information'
-import DetailsSideItem, { InformationModel, TitleType } from '../../_ui/details-side-item'
+import { InformationModel, TitleType } from '../../_ui/details-side-item'
+import SideSkeleton from '../../_ui/details-side-item/side-skeleton'
 import useGetSubscribe from '../_hooks/query/use-get-subscribe'
 import SideContainer from '../_ui/side-container'
 import useGetDetailsInformationData from './_hooks/query/use-get-details-information-data'
-import ReviewContainer from './_ui/review-container'
+import DetailsLoading from './loading'
+
+const DetailsInformation = React.lazy(() => import('../../_ui/details-information'))
+const AnalysisContainer = React.lazy(() => import('@/app/(dashboard)/_ui/analysis-container'))
+const ReviewContainer = React.lazy(() => import('./_ui/review-container'))
+const SubscriberItem = React.lazy(() => import('@/app/(dashboard)/_ui/subscriber-item'))
+const DetailsSideItem = React.lazy(() => import('../../_ui/details-side-item'))
+
+const DynamicSkeleton = dynamic(() => import('./loading'), {
+  loading: () => <DetailsLoading />,
+  ssr: false,
+})
+
+const DynamicSideSkeleton = dynamic(() => import('../../_ui/details-side-item/side-skeleton'), {
+  loading: () => <SideSkeleton />,
+  ssr: false,
+})
 
 export type InformationType = { title: TitleType; data: string | number } | InformationModel[]
 
@@ -51,15 +68,19 @@ const StrategyDetailPage = ({ params }: { params: { strategyId: number } }) => {
 
   return (
     <>
-      <div>
-        <BackHeader label={'목록으로 돌아가기'} />
-        <Title label={'전략 상세보기'} />
+      <BackHeader label={'목록으로 돌아가기'} />
+      <Title label={'전략 상세보기'} />
+      <Suspense fallback={<DynamicSkeleton />}>
         {information && (
-          <DetailsInformation information={information} strategyId={params.strategyId} />
+          <>
+            <DetailsInformation information={information} strategyId={params.strategyId} />
+            <AnalysisContainer strategyId={params.strategyId} />
+            <ReviewContainer strategyId={params.strategyId} />
+          </>
         )}
-        <AnalysisContainer strategyId={params.strategyId} />
-        <ReviewContainer strategyId={params.strategyId} />
-        <SideContainer>
+      </Suspense>
+      <SideContainer>
+        <Suspense fallback={<DynamicSideSkeleton />}>
           {information && (
             <SubscriberItem
               isMyStrategy={user?.nickname === information.nickname}
@@ -80,8 +101,8 @@ const StrategyDetailPage = ({ params }: { params: { strategyId: number } }) => {
                 />
               </div>
             ))}
-        </SideContainer>
-      </div>
+        </Suspense>
+      </SideContainer>
       {isModalOpen && information && (
         <SubscribeCheckModal
           isSubscribing={information?.isSubscribed}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

전략 상세 로딩 스켈레톤 추가 및 적용

## 🔧 변경 사항

- 전략목록과 다르게 전략상세는 클라이언트컴포넌트로 되어있어 suspense fallback ui가 잘 보이도록 skeleton컴포넌트는 Next/dynamic, 하위 컴포넌트는 React.lazy import를 사용하여  적용했습니다. -> (복습 필요^^..)

## 📸 스크린샷 (권장)

<img width="1386" alt="스크린샷 2024-12-05 오후 11 27 09" src="https://github.com/user-attachments/assets/c7539ab9-6627-4e90-a362-a9b7550730c1">

## 🙏 리뷰 참고 (선택 사항)

> 개발 과정에서 다른 분들의 의견이 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요.

## 📄 기타 (선택 사항)

> 그 외 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
