### PR TITLE
[Feat] 분석 탭에 데이터 없을 경우 ui 통일하여 추가

### DIFF
--- a/app/(dashboard)/_ui/analysis-container/analysis-content.tsx
+++ b/app/(dashboard)/_ui/analysis-container/analysis-content.tsx
@@ -110,8 +110,6 @@ const AnalysisContent = ({
     }
   }
 
-  if (analysisData?.content === null || analysisData?.content === undefined) return null
-
   return (
     <div className={cx('table-wrapper', 'analysis')}>
       {!isEditable && (
@@ -149,19 +147,22 @@ const AnalysisContent = ({
           </Button>
         </div>
       )}
-
-      <VerticalTable
-        tableHead={tableHeader}
-        tableBody={analysisData?.content}
-        currentPage={currentPage}
-        countPerPage={ANALYSIS_PAGE_COUNT}
-        isEditable={isEditable}
-      />
-      <Pagination
-        currentPage={currentPage}
-        maxPage={analysisData?.totalPages}
-        onPageChange={onPageChange}
-      />
+      {analysisData && (
+        <>
+          <VerticalTable
+            tableHead={tableHeader}
+            tableBody={analysisData.content}
+            currentPage={1}
+            countPerPage={ANALYSIS_PAGE_COUNT}
+            isEditable={isEditable}
+          />
+          <Pagination
+            currentPage={currentPage}
+            maxPage={analysisData.totalPages}
+            onPageChange={onPageChange}
+          />
+        </>
+      )}
 
       {uploadType && (
         <AnalysisUploadModal

--- a/app/(dashboard)/_ui/analysis-container/analysis-content.tsx
+++ b/app/(dashboard)/_ui/analysis-container/analysis-content.tsx
@@ -112,43 +112,43 @@ const AnalysisContent = ({
 
   return (
     <div className={cx('table-wrapper', 'analysis')}>
+      {!isEditable && analysisData && (
+        <Button
+          onClick={handleDownload}
+          size="small"
+          className={cx('excel-button')}
+          variant="filled"
+        >
+          엑셀 다운받기
+        </Button>
+      )}
+      {isEditable && (
+        <div className={cx('button-container')}>
+          <div className={cx('button-wrapper')}>
+            <Button
+              size="small"
+              className={cx('upload-button')}
+              variant="filled"
+              onClick={handleExcelUpload}
+            >
+              엑셀 업로드
+            </Button>
+            <Button
+              size="small"
+              className={cx('upload-button')}
+              variant="filled"
+              onClick={handleDirectInput}
+            >
+              직접 입력
+            </Button>
+          </div>
+          <Button size="small" variant="filled" onClick={handleDeleteAll} disabled={isLoading}>
+            전체 삭제
+          </Button>
+        </div>
+      )}
       {analysisData ? (
         <>
-          {!isEditable && (
-            <Button
-              onClick={handleDownload}
-              size="small"
-              className={cx('excel-button')}
-              variant="filled"
-            >
-              엑셀 다운받기
-            </Button>
-          )}
-          {isEditable && (
-            <div className={cx('button-container')}>
-              <div className={cx('button-wrapper')}>
-                <Button
-                  size="small"
-                  className={cx('upload-button')}
-                  variant="filled"
-                  onClick={handleExcelUpload}
-                >
-                  엑셀 업로드
-                </Button>
-                <Button
-                  size="small"
-                  className={cx('upload-button')}
-                  variant="filled"
-                  onClick={handleDirectInput}
-                >
-                  직접 입력
-                </Button>
-              </div>
-              <Button size="small" variant="filled" onClick={handleDeleteAll} disabled={isLoading}>
-                전체 삭제
-              </Button>
-            </div>
-          )}
           <VerticalTable
             tableHead={tableHeader}
             tableBody={analysisData.content}

--- a/app/(dashboard)/_ui/analysis-container/analysis-content.tsx
+++ b/app/(dashboard)/_ui/analysis-container/analysis-content.tsx
@@ -112,43 +112,43 @@ const AnalysisContent = ({
 
   return (
     <div className={cx('table-wrapper', 'analysis')}>
-      {!isEditable && (
-        <Button
-          onClick={handleDownload}
-          size="small"
-          className={cx('excel-button')}
-          variant="filled"
-        >
-          엑셀 다운받기
-        </Button>
-      )}
-      {isEditable && (
-        <div className={cx('button-container')}>
-          <div className={cx('button-wrapper')}>
-            <Button
-              size="small"
-              className={cx('upload-button')}
-              variant="filled"
-              onClick={handleExcelUpload}
-            >
-              엑셀 업로드
-            </Button>
-            <Button
-              size="small"
-              className={cx('upload-button')}
-              variant="filled"
-              onClick={handleDirectInput}
-            >
-              직접 입력
-            </Button>
-          </div>
-          <Button size="small" variant="filled" onClick={handleDeleteAll} disabled={isLoading}>
-            전체 삭제
-          </Button>
-        </div>
-      )}
-      {analysisData && (
+      {analysisData ? (
         <>
+          {!isEditable && (
+            <Button
+              onClick={handleDownload}
+              size="small"
+              className={cx('excel-button')}
+              variant="filled"
+            >
+              엑셀 다운받기
+            </Button>
+          )}
+          {isEditable && (
+            <div className={cx('button-container')}>
+              <div className={cx('button-wrapper')}>
+                <Button
+                  size="small"
+                  className={cx('upload-button')}
+                  variant="filled"
+                  onClick={handleExcelUpload}
+                >
+                  엑셀 업로드
+                </Button>
+                <Button
+                  size="small"
+                  className={cx('upload-button')}
+                  variant="filled"
+                  onClick={handleDirectInput}
+                >
+                  직접 입력
+                </Button>
+              </div>
+              <Button size="small" variant="filled" onClick={handleDeleteAll} disabled={isLoading}>
+                전체 삭제
+              </Button>
+            </div>
+          )}
           <VerticalTable
             tableHead={tableHeader}
             tableBody={analysisData.content}
@@ -162,6 +162,10 @@ const AnalysisContent = ({
             onPageChange={onPageChange}
           />
         </>
+      ) : (
+        <div className={cx('no-data')}>
+          <p>업데이트 된 분석 데이터가 없습니다.</p>
+        </div>
       )}
 
       {uploadType && (

--- a/app/(dashboard)/_ui/analysis-container/statistics-content.tsx
+++ b/app/(dashboard)/_ui/analysis-container/statistics-content.tsx
@@ -18,15 +18,17 @@ interface Props {
 }
 
 const StatisticsContent = ({ statisticsData }: Props) => {
-  if (statisticsData === null || statisticsData === undefined) return null
-
-  const statisticsDataToArray = Object.entries(statisticsData)
-
   return (
     <div className={cx('table-wrapper')}>
-      {statisticsDataToArray.map(([title, data]) => (
-        <StatisticsTable key={title} title={title} statisticsData={data} />
-      ))}
+      {statisticsData ? (
+        Object.entries(statisticsData).map(([title, data]) => (
+          <StatisticsTable key={title} title={title} statisticsData={data} />
+        ))
+      ) : (
+        <div className={cx('no-data')}>
+          <p>업데이트 된 통계 데이터가 없습니다.</p>
+        </div>
+      )}
     </div>
   )
 }

--- a/app/(dashboard)/_ui/analysis-container/styles.module.scss
+++ b/app/(dashboard)/_ui/analysis-container/styles.module.scss
@@ -91,9 +91,10 @@
 .no-data {
   display: flex;
   justify-content: center;
-  margin: 60px 0 40px;
+  margin-top: 80px;
   color: $color-gray-600;
-  @include typo-b2;
+  height: 200px;
+  @include typo-b1;
 }
 
 .button-container {

--- a/app/(dashboard)/_ui/details-information/styles.module.scss
+++ b/app/(dashboard)/_ui/details-information/styles.module.scss
@@ -36,6 +36,7 @@
     width: 100%;
     height: 100%;
     border-right: 1px solid $color-gray-200;
+    padding-right: 4px;
     &:last-child {
       border-right: 0;
     }

--- a/app/(dashboard)/my/_hooks/query/use-get-my-daily-analysis.ts
+++ b/app/(dashboard)/my/_hooks/query/use-get-my-daily-analysis.ts
@@ -4,7 +4,7 @@ import getMyDailyAnalysis from '../../_api/get-my-daily-analysis'
 
 const useGetAnalysis = (strategyId: number, page: number, size: number) => {
   return useQuery({
-    queryKey: ['myDailyAnalysis', strategyId],
+    queryKey: ['myDailyAnalysis', strategyId, page],
     queryFn: () => getMyDailyAnalysis(strategyId, page, size),
   })
 }

--- a/app/(dashboard)/strategies/[strategyId]/_hooks/query/use-get-analysis.ts
+++ b/app/(dashboard)/strategies/[strategyId]/_hooks/query/use-get-analysis.ts
@@ -5,7 +5,7 @@ import getAnalysis from '../../_api/get-analysis'
 
 const useGetAnalysis = (strategyId: number, type: AnalysisTabType, page: number, size: number) => {
   return useQuery({
-    queryKey: ['analysis', strategyId, type],
+    queryKey: ['analysis', strategyId, type, page],
     queryFn: () => getAnalysis(strategyId, type, page, size),
   })
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

분석 탭에 데이터 없을 경우 ui 통일하여 추가

## 🔧 변경 사항

- 분석 탭에 데이터 없을 경우 ui 통일하여 추가
- 쿼리키 Page 누락되어 데이터 캐시되서 요청이 안되고있었음 -> 해결

## 📸 스크린샷 (권장)

> 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 🙏 리뷰 참고 (선택 사항)

> 개발 과정에서 다른 분들의 의견이 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요.

## 📄 기타 (선택 사항)

> 그 외 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
